### PR TITLE
(MAINT) Update jvm-ssl-utils to 0.8.2, prep for 0.1.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [0.1.7] - 2016-10-26
+- Updated jvm-ssl-utils to 0.8.2.
+
+## [0.1.6] - 2016-10-26
+- Updated commons-codec to 1.10 and ring-servlet to 1.5.0.
+
+## [0.1.5] - 2016-10-25
+- Updated compojure to 1.5.0 and trapperkeeper-status to 0.5.0.
+- Added jdbc-util, version 0.4.15.
+
+## [0.1.4] - 2016-10-07
+- Updated tools.logging to 0.3.1 and tools.macro to 0.1.5.
+
 ## [0.1.3] - 2016-10-05
 - KS version was incorrectly set to 1.3.2, fixed to 1.4.0.
 

--- a/project.clj
+++ b/project.clj
@@ -56,7 +56,7 @@
                          [puppetlabs/http-client "0.5.0"]
                          [puppetlabs/jdbc-util "0.4.15"]
                          [puppetlabs/typesafe-config "0.1.5"]
-                         [puppetlabs/ssl-utils "0.8.1"]
+                         [puppetlabs/ssl-utils "0.8.2"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]
                          [puppetlabs/trapperkeeper ~tk-version]


### PR DESCRIPTION
This commit updates the jvm-ssl-utils dependency from 0.8.1 to 0.8.2 and
updates the CHANGELOG.md for the 0.1.4 - 0.1.7 releases.