### PR TITLE
(PE-18217) Add clojurescript and prep CHANGELOG for 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.3] - 2016-11-08
+
+- Adds org.clojure/clojurescript at version 1.7.122.
+
 ## [0.2.2] - 2016-11-08
 
 - Updates puppetlabs/dujour-version-check to 0.2.1.

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
   :pedantic? :abort
 
   :managed-dependencies [[org.clojure/clojure ~clj-version]
+                         [org.clojure/clojurescript "1.7.122"]
                          [org.clojure/tools.logging "0.3.1"]
                          [org.clojure/tools.cli "0.3.4"]
                          [org.clojure/tools.nrepl "0.2.6"]


### PR DESCRIPTION
This commit adds clojurescript to the parent project.  This is
necessary in order to make sure that pe-puppet-server-extensions
and pe-puppetserver agree on what version of clojurescript to use.