### PR TITLE
(maint) Update clj-http-client dependency to 0.7.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -71,7 +71,7 @@
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.1"]
 
-                         [puppetlabs/http-client "0.5.0"]
+                         [puppetlabs/http-client "0.7.0"]
                          [puppetlabs/jdbc-util "0.5.0"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "0.8.3"]


### PR DESCRIPTION
This commit updates the clj-http-client dependency which now
automatically adds the accept-language header to outgoing requests.