### PR TITLE
(MAINT) Bump tk-jetty9 to 1.7.0 and prep for 0.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.3.3] - 2017-01-24
+
+- Updates `trapperkeeper-webserver-jetty9` to 1.7.0.
+- Updates `clj-i18n` to 0.6.0.
+
 ## [0.3.2] - 2017-01-17
 
 - Updates 'trapperkeeper-webserver-jetty9' to 1.6.0.

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.8.0")
 (def ks-version "2.1.0")
 (def tk-version "1.5.2")
-(def tk-jetty-version "1.6.0")
+(def tk-jetty-version "1.7.0")
 (def pe-tk-metrics-version "0.2.1")
 (def logback-version "1.1.7")
 


### PR DESCRIPTION
This commit bumps the tk-jetty9 version from 1.6.0 to 1.7.0 and updates the CHANGELOG.md file for an 0.3.3 release.