### PR TITLE
(TK-428) Upgrade logback for totalLogSize rotation fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
 (def tk-version "1.5.2")
 (def tk-jetty-version "1.7.0")
 (def pe-tk-metrics-version "0.2.1")
-(def logback-version "1.1.7")
+(def logback-version "1.1.9")
 
 (defproject puppetlabs/clj-parent "0.3.4-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in


### PR DESCRIPTION
Logback 1.1.8 is strictly necessary to fix this bug (according to the changelog/ticket but 1.1.9 is the latest by the time work was started. 1.1.9 increases the size of it's threadpool to hopefully improve configuration scanning.