### PR TITLE
(MAINT) Bump http-client to 0.8.0 and prep for 0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.4.1] - 2017-02-10
+
+- Updates `puppetlabs/http-client` to 0.8.0.
+
 ## [0.4.0] - 2017-02-08
 
 - Updates `logback` to 1.1.9.

--- a/project.clj
+++ b/project.clj
@@ -80,7 +80,7 @@
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.1"]
 
-                         [puppetlabs/http-client "0.7.0"]
+                         [puppetlabs/http-client "0.8.0"]
                          [puppetlabs/jdbc-util "0.5.0"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "0.8.3"]


### PR DESCRIPTION
This commit bumps the puppetlabs/http-client dependency from 0.7.0 to
0.8.0 and updates the CHANGELOG.md file for the 0.4.1 release.