### PR TITLE
(maint) Update clj-yaml to a maintained version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
                          [joda-time "2.8.2"]
 
                          [clj-time "0.11.0"]
-                         [clj-yaml "0.4.0"]
+                         [circleci/clj-yaml "0.5.5"]
                          [clj-stacktrace "0.2.8"]
                          [me.raynes/fs "1.4.6"]
                          [slingshot "0.12.2"]


### PR DESCRIPTION
circleci/clj-yaml is a maintained version of the original clj-yaml
project that was last updated in 2012. This commit updates the
dependency to circleci's fork.