### PR TITLE
(MAINT) Update version for 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.5.0] - 2017-03-13
+
+- Adds dependency for `io.dropwizard.metrics/metrics-core` 3.1.2
+- Updates `puppetlabs/trapperkeeper-metrics` to 1.0.0
+- Removes dependency on `puppetlabs/pe-trapperkeeper-metrics`
+
 ## [0.4.1] - 2017-02-10
 
 - Updates `puppetlabs/http-client` to 0.8.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 - Adds dependency for `io.dropwizard.metrics/metrics-core` 3.1.2
 - Updates `puppetlabs/trapperkeeper-metrics` to 1.0.0
+- Updates `puppetlabs/i18n` to 0.7.0
 - Removes dependency on `puppetlabs/pe-trapperkeeper-metrics`
+
+It should be noted that `puppetlabs/trapperkeeper-metrics` 1.0.0 introduces
+some breaking changes in the `metrics` section of its trapperkeeper
+configuration. Projects which require `trapperkeeper-metrics` will need to be
+updated. See the [documentation](https://github.com/puppetlabs/trapperkeeper-metrics/blob/1.0.0/documentation/configuration.md)
+for details
 
 ## [0.4.1] - 2017-02-10
 

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
 (def tk-metrics-version "1.0.0")
 (def logback-version "1.1.9")
 
-(defproject puppetlabs/clj-parent "0.4.2-SNAPSHOT"
+(defproject puppetlabs/clj-parent "0.5.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.


### PR DESCRIPTION
- Adds dependency for io.dropwizard.metrics/metrics-core 3.1.2
- Updates puppetlabs/trapperkeeper-metrics to 1.0.0
- Removes dependency on puppetlabs/pe-trapperkeeper-metrics