### PR TITLE
(maint) Bump clj-i18n to 0.7.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -101,7 +101,7 @@
                          [puppetlabs/dujour-version-check "0.2.1"]
                          [puppetlabs/comidi "0.3.1"]
                          [puppetlabs/trapperkeeper-comidi-metrics "0.1.1"]
-                         [puppetlabs/i18n "0.7.0"]
+                         [puppetlabs/i18n "0.7.1"]
                          [puppetlabs/cljs-dashboard-widgets "0.1.0"]
                          ]
 


### PR DESCRIPTION
This commit picks up changes to clj-i18n that removes the use and generation of English bundles if an en.po is not present. Opting instead to fallback to the POT as intended. This work also fixes a bug surfacing GNU gettext treatment of empty strings. Prior to this commit, empty strings would display the header of the POT file. Now an externalized empty string displays an empty string.