### PR TITLE
(maint) Add rbac-client to clj-parent

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -103,6 +103,7 @@
                          [puppetlabs/trapperkeeper-comidi-metrics "0.1.1"]
                          [puppetlabs/i18n "0.7.1"]
                          [puppetlabs/cljs-dashboard-widgets "0.1.0"]
+                         [puppetlabs/rbac-client "0.6.1"]
                          ]
 
   :dependencies [[org.clojure/clojure]]


### PR DESCRIPTION
There have been a few cases where rbac-client has fallen behind in
project dependencies. This commit adds rbac-client to clj-parent so that
projects that are up to date with their parent release will also be up
to date with rbac-client.