### PR TITLE
(SERVER-1630) Bump snakeyaml version to 1.18

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                          [net.logstash.logback/logstash-logback-encoder "4.7"]
                          [org.codehaus.janino/janino "2.7.8"]
                          [com.fasterxml.jackson.core/jackson-core "2.7.3"]
-                         [org.yaml/snakeyaml "1.13"]
+                         [org.yaml/snakeyaml "1.18"]
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]
                          [org.apache.commons/commons-exec "1.3"]


### PR DESCRIPTION
This commit bumps the org.yaml/snakeyaml version from 1.13 to 1.18, for
compatibility with the version used in the latest JRuby, 9.1.8.0.  Per
issue #323 in the snakeyaml bitbucket project, 1.18 does have some minor
breaking changes (method signature changes).  None of the changes
appear to be exposed / utilized from clj-yaml.  The next clj-parent
release which has this bump should probably be at least a Y version,
though, for visibility.