### PR TITLE
(MAINT) Add asm-all dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -87,6 +87,7 @@
                          [trptcolin/versioneer "0.2.0"]
                          [io.dropwizard.metrics/metrics-core "3.1.2"]
                          [metrics-clojure "2.6.1"]
+                         [org.ow2.asm/asm-all "5.0.3"]
 
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.1"]


### PR DESCRIPTION
This commit adds org.ow2.asm/asm-all.  This is being included to help
mitigate conflicts which arise between the version of asm-all (4.2)
that org.clojure/core.async (0.2.391) pulls in transitively via
org.clojure/tools.analyzer.jvm (0.6.10) and what JRuby (1.7.26+) uses,
asm-all (5.0.3).