### PR TITLE
(maint) update jdbc-util to 1.0.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -93,7 +93,7 @@
                          [prismatic/schema "1.1.1"]
 
                          [puppetlabs/http-client "0.8.0"]
-                         [puppetlabs/jdbc-util "1.0.0"]
+                         [puppetlabs/jdbc-util "1.0.1"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "0.8.3"]
                          [puppetlabs/kitchensink ~ks-version]


### PR DESCRIPTION
jdbc-util had a potential uncaught exception during migrations on
replicas.  This updates to a version that correctly catches and
logs the exception.