### PR TITLE
(TK-442) Update io.dropwizard.metrics/metrics-core to 3.2.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -85,7 +85,7 @@
                          [liberator "0.12.0"]
                          [org.tcrawley/dynapath "0.2.4"]
                          [trptcolin/versioneer "0.2.0"]
-                         [io.dropwizard.metrics/metrics-core "3.1.2"]
+                         [io.dropwizard.metrics/metrics-core "3.2.2"]
                          [metrics-clojure "2.6.1"]
                          [org.ow2.asm/asm-all "5.0.3"]
 

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
 (def tk-metrics-version "1.0.0")
 (def logback-version "1.1.9")
 (def rbac-client-version "0.7.0")
+(def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "1.1.1-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
@@ -85,7 +86,8 @@
                          [liberator "0.12.0"]
                          [org.tcrawley/dynapath "0.2.4"]
                          [trptcolin/versioneer "0.2.0"]
-                         [io.dropwizard.metrics/metrics-core "3.2.2"]
+                         [io.dropwizard.metrics/metrics-core ~dropwizard-metrics-version]
+                         [io.dropwizard.metrics/metrics-graphite ~dropwizard-metrics-version]
                          [metrics-clojure "2.6.1"]
                          [org.ow2.asm/asm-all "5.0.3"]
 


### PR DESCRIPTION
This updates our dropwizard dependency to the latest release to pick up
a fix for a memory leak.

This version of dropwizard also provides native support for blacklisting
metrics attributes (eg. "p99", "m15").  Any downstream projects that
have implemented their own GraphiteReporter for blacklisting
functionality can now move to using the built in feature.

---

I created a version of [Puppet Server 5](http://builds.delivery.puppetlabs.net/puppetserver/5.0.0.master.SNAPSHOT.2017.06.06T2339/repo_configs/rpm/) using this code and attempted to replicate the [memory & cpu testing](https://tickets.puppetlabs.com/browse/SERVER-1735?focusedCommentId=449039&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-449039) that we did when we introduced this library. The [results](https://docs.google.com/spreadsheets/d/1N6aQiRHFq_JvY4amq_mBB8v2_hIK9OQE7QjysuqG-zg/edit#gid=1577412672) show
 * fewer scavenging counts leading to less total time than before the library was even added (probably an overall improvement within Puppet 5)
 * similar heap usage to when the metrics were disabled


NB: I need to confirm with @rlinehan that my assumptions are actually valid. My impression is that metrics collection is on by default and so no additional configuration was needed. I also did not have the server connected to PuppetDB. I've created a script to process the JSON collected by the test [script](https://gist.github.com/justinstoller/60c1419d3c4a69a9d0234f74644088e2) so that it can be uploaded to the linked spreadsheet and the graphs will automatically update so it should trivial to recreate if my setup assumptions were incorrect.