### PR TITLE
(maint) jdbc-utils 1.0.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -95,7 +95,7 @@
                          [prismatic/schema "1.1.1"]
 
                          [puppetlabs/http-client "0.8.0"]
-                         [puppetlabs/jdbc-util "1.0.1"]
+                         [puppetlabs/jdbc-util "1.0.2"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "0.8.3"]
                          [puppetlabs/kitchensink ~ks-version]


### PR DESCRIPTION
Bumps jdbc-utils to fix "WARN  [c.z.h.HikariConfig] The initializationFailFast propery is deprecated, see initializationFailTimeout"