### PR TITLE
(TK-452) Update tk-webserver-jetty9 to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.4.1]
+
+- Update `trapperkeeper-webserver-jetty9` to version 2.1.0
+
 ## [1.4.0]
 
 - Update `cheshire` to 5.8.0

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.8.0")
 (def ks-version "2.4.0")
 (def tk-version "1.5.2")
-(def tk-jetty-version "2.0.1")
+(def tk-jetty-version "2.1.0")
 (def tk-metrics-version "1.1.0")
 (def logback-version "1.1.9")
 (def rbac-client-version "0.7.0")


### PR DESCRIPTION
This version of tk-jetty9 includes code to perform runtime refreshes of
the CRL.