### PR TITLE
(maint) Add jackson-databind @ 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.4.2]
+
+- Add `jackson-databind` at version 2.9.0
+
 ## [1.4.1]
 
 - Update `trapperkeeper-webserver-jetty9` to version 2.1.0

--- a/project.clj
+++ b/project.clj
@@ -38,6 +38,7 @@
                          [net.logstash.logback/logstash-logback-encoder "4.7"]
                          [org.codehaus.janino/janino "2.7.8"]
                          [com.fasterxml.jackson.core/jackson-core "2.9.0"]
+                         [com.fasterxml.jackson.core/jackson-databind "2.9.0"]
                          [org.yaml/snakeyaml "1.18"]
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]


### PR DESCRIPTION
This transitive dependency has been observed to conflict between
pe-puppetdb-extensions and orchestrator. This version is the most recent
of the conflicting versions, and using it with pe-puppetdb-extensions
does not appear to cause any overt problems in PuppetDB.