### PR TITLE
(maint) update rbac-client to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.4.2]
+
+- Update `puppetlabs/rbac-client` to version 0.7.1
+
 ## [1.4.1]
 
 - Update `trapperkeeper-webserver-jetty9` to version 2.1.0

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "2.1.0")
 (def tk-metrics-version "1.1.0")
 (def logback-version "1.1.9")
-(def rbac-client-version "0.7.0")
+(def rbac-client-version "0.7.1")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "1.4.2-SNAPSHOT"


### PR DESCRIPTION
Update the rbac-client depdendency to 0.7.1

Update the CHANGELOG in anticipation of a version 1.4.2 release