### PR TITLE
(PE-23159): bumping rbac client version for consumer change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.5.0]
+
+- Update `puppetlabs/rbac-client-version` to version 0.8.1
+- Breaking change: the new version of the rbac client includes a new method within the RbacConsumerService protocol, and dependent projects will require updating to accommodate for it.
+
 ## [1.4.3]
 
 - Update `puppetlabs/clj-kitchensink` to version 2.5.0
@@ -67,7 +72,7 @@ Jetty version from 9.2.10 to 9.4.4.  Both tk-webserver-jetty9 and Jetty
 - Add `commons-beanutils` at version 1.9.2
 - Add `commons-collections` at version 3.2.2
 
-## [0.8.0] - 2017-04-27 
+## [0.8.0] - 2017-04-27
 - Update `jdbc-util` to 1.0.0
 - Add `com.zaxxer/HikariCP` at version 2.6.1
 

--- a/project.clj
+++ b/project.clj
@@ -4,10 +4,10 @@
 (def tk-jetty-version "2.1.0")
 (def tk-metrics-version "1.1.0")
 (def logback-version "1.1.9")
-(def rbac-client-version "0.7.1")
+(def rbac-client-version "0.8.1")
 (def dropwizard-metrics-version "3.2.2")
 
-(defproject puppetlabs/clj-parent "1.4.4-SNAPSHOT"
+(defproject puppetlabs/clj-parent "1.5.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.


### PR DESCRIPTION
This commit bumps the rbac-client version for the project to include the new method added to the consumer service, which allows service calls for permitted instances with token authentication. 

The changes also bump the clj-parent version with a minor increase, as the clj-rbac-client changeset is a breaking change to rbac because it updates the RbacConsumerService protocol. 