### PR TITLE
(maint) update puppetlabs/jdbc-util to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.5.1]
+
+- update `puppetlabs/jdbc-util` to version 1.0.3 which includes updates for the postgres driver and HikariCP
+- add a depdendecy to 'org.postgres/postgres' version 42.1.4
+
 ## [1.5.0]
 
 - Update `puppetlabs/rbac-client-version` to version 0.8.1

--- a/project.clj
+++ b/project.clj
@@ -86,12 +86,13 @@
                          [metrics-clojure "2.6.1"]
                          [org.ow2.asm/asm-all "5.0.3"]
                          [honeysql "0.6.3"]
+                         [org.postgresql/postgresql "42.1.4"]
 
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.1"]
 
                          [puppetlabs/http-client "0.9.0"]
-                         [puppetlabs/jdbc-util "1.0.2"]
+                         [puppetlabs/jdbc-util "1.0.3"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "0.9.1"]
                          [puppetlabs/kitchensink ~ks-version]


### PR DESCRIPTION
Update the version of puppetlabs/jdbc-util to 1.0.3 which includes dupdates for the postgres driver and HikariCP.

Update the changelog in preparation for a release.