### PR TITLE
(maint) Update trapperkeeper and kitchensink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.6.3]
+
+- Update `puppetlabs/clj-kitchensink` to version 2.5.2 for Java 9 compatibility.
+- Update `puppetlabs/trapperkeeper` to version 1.5.4 for Java 9 compatibility.
+
 ## [1.6.2]
 
 - update bidi to 2.1.3, which avoids a bug when parsing URIs with spaces. Also update comidi to 0.3.2, to be compatible with the new bidi.

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.8.0")
-(def ks-version "2.5.1")
-(def tk-version "1.5.3")
+(def ks-version "2.5.2")
+(def tk-version "1.5.4")
 (def tk-jetty-version "2.1.1")
 (def tk-metrics-version "1.1.0")
 (def logback-version "1.1.9")


### PR DESCRIPTION
These contain changes to make them work with Java 9.