### PR TITLE
(SERVER-2118) Update tk-jetty9 to 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.1]
+
+- Update trapperkeeper-webserver-jetty9 to 2.1.2, which enables gzipping of POST request responses
+
 ## [1.7.0]
 
 - Update for Java 9 compatibility, minor version bump because some of these are feature releases

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.8.0")
 (def ks-version "2.5.2")
 (def tk-version "1.5.5")
-(def tk-jetty-version "2.1.1")
+(def tk-jetty-version "2.1.2")
 (def tk-metrics-version "1.1.0")
 (def logback-version "1.1.9")
 (def rbac-client-version "0.8.1")


### PR DESCRIPTION
This update of tk-jetty9 allows POST reqest responses to be gzipped when
using Jetty 9.4. This fixes a regression from the 1.x branch of
tk-jetty9, which uses an older version of Jetty.