### PR TITLE
(PE-23667) update jdbc-util to 1.1.1 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.2]
+
+- update jdbc-util to 1.1.1 to fix issue with pglogical activated during migrations.
+
 ## [1.7.1]
 
 - Update trapperkeeper-webserver-jetty9 to 2.1.2, which enables gzipping of POST request responses

--- a/project.clj
+++ b/project.clj
@@ -92,7 +92,7 @@
                          [prismatic/schema "1.1.1"]
 
                          [puppetlabs/http-client "0.9.0"]
-                         [puppetlabs/jdbc-util "1.1.0"]
+                         [puppetlabs/jdbc-util "1.1.1"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "0.9.1"]
                          [puppetlabs/kitchensink ~ks-version]


### PR DESCRIPTION
This updates jdbc-util to 1.1.1 to address some issues with pglogical
and migratus migrations.