### PR TITLE
(SERVER-2098) Add afterburner and update jackson to 2.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## [1.7.3]
+
+- Update Jackson to 2.9.4 and pull in the Jackson Afterburner module for use with JrJackson.
+
 ## [1.7.2]
 
-- update jdbc-util to 1.1.1 to fix issue with pglogical activated during migrations.
+- Update jdbc-util to 1.1.1 to fix issue with pglogical activated during migrations.
 
 ## [1.7.1]
 

--- a/project.clj
+++ b/project.clj
@@ -37,8 +37,9 @@
                          [ch.qos.logback/logback-access ~logback-version]
                          [net.logstash.logback/logstash-logback-encoder "4.7"]
                          [org.codehaus.janino/janino "2.7.8"]
-                         [com.fasterxml.jackson.core/jackson-core "2.9.0"]
-                         [com.fasterxml.jackson.core/jackson-databind "2.9.1"]
+                         [com.fasterxml.jackson.core/jackson-core "2.9.4"]
+                         [com.fasterxml.jackson.core/jackson-databind "2.9.4"]
+                         [com.fasterxml.jackson.module/jackson-module-afterburner "2.9.4"]
                          [org.yaml/snakeyaml "1.18"]
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]


### PR DESCRIPTION
The JrJackson gem allows Jackson to be used from Ruby and requires
Jackson's Afterburner module. This commit brings that in and updates all
other Jackson libraries to 2.9.4, the latest release.