### PR TITLE
(maint) Bump janino version to 3.0.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
                          [ch.qos.logback/logback-core ~logback-version]
                          [ch.qos.logback/logback-access ~logback-version]
                          [net.logstash.logback/logstash-logback-encoder "5.0"]
-                         [org.codehaus.janino/janino "2.7.8"]
+                         [org.codehaus.janino/janino "3.0.8"]
                          [com.fasterxml.jackson.core/jackson-core "2.9.4"]
                          [com.fasterxml.jackson.core/jackson-databind "2.9.4"]
                          [com.fasterxml.jackson.module/jackson-module-afterburner "2.9.4"]


### PR DESCRIPTION
This commit bumps the janino version from 2.7.z to 3.0.z in order to keep pace
with Logback 1.2.