### PR TITLE
(PDB-3942) Raise liberator dependency to java 9 compatible

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -79,7 +79,7 @@
                          [stencil "0.5.0"]
                          [beckon "0.1.1"]
                          [hiccup "1.0.5"]
-                         [liberator "0.12.0"]
+                         [liberator "0.15.2"]
                          [org.tcrawley/dynapath "0.2.4"]
                          [trptcolin/versioneer "0.2.0"]
                          [io.dropwizard.metrics/metrics-core ~dropwizard-metrics-version]


### PR DESCRIPTION
Liberator can be made Java 9/10 compatible with the appropriate flags,
but without them, version 0.12 is not 9/10 compatible. Also there will
be no flag available to make liberator 0.12 compatible with Java 11.

This changes liberators version to the minimum required for 9/10
compatiblility without additional flags and the minimum required for
Java 11 compatibility.