### PR TITLE
(maint) update jdbc-util to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+## [2.0.5]
+
+- Update `jdbc-util` to 1.2.1
+
 ## [2.0.4]
 
 - Update `jdbc-util` to 1.2.0
+
 ## [2.0.3]
 
 - Update `trapperkeeper-status` to 1.1.0

--- a/project.clj
+++ b/project.clj
@@ -93,7 +93,7 @@
                          [prismatic/schema "1.1.1"]
 
                          [puppetlabs/http-client "0.9.0"]
-                         [puppetlabs/jdbc-util "1.2.0"]
+                         [puppetlabs/jdbc-util "1.2.1"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "1.0.0"]
                          [puppetlabs/clj-ldap "0.1.6"]


### PR DESCRIPTION
This version of jdbc-util supports interruptions of migrations
and properly closes the database connection for replications.