### PR TITLE
(maint) update jdbc-util and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.6]
+
+- Update `jdbc-util` to 1.2.2
+- update `org.clojure/java.jdbc` to 0.7.7
+
 ## [2.0.5]
 
 - Update `jdbc-util` to 1.2.1

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                          [org.clojure/tools.nrepl "0.2.13"]
                          [org.clojure/tools.macro "0.1.5"]
                          [org.clojure/java.classpath "0.2.3"]
-                         [org.clojure/java.jdbc "0.7.5"]
+                         [org.clojure/java.jdbc "0.7.7"]
                          [org.clojure/java.jmx "0.3.4"]
                          [org.clojure/core.async "0.4.474"]
                          [org.clojure/core.cache "0.7.1"]
@@ -93,7 +93,7 @@
                          [prismatic/schema "1.1.1"]
 
                          [puppetlabs/http-client "0.9.0"]
-                         [puppetlabs/jdbc-util "1.2.1"]
+                         [puppetlabs/jdbc-util "1.2.2"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "1.0.0"]
                          [puppetlabs/clj-ldap "0.1.6"]


### PR DESCRIPTION
This updates jdbc-util to 1.2.2, which updates the dependency on migratus
to a newer version that implements the functionality added in jdbc-util 1.2.1

This allowed simplification in jdbc-util.  It also brings in a newer version
of java.jdbc that contains a few fixes.