### PR TITLE
(PE-24735) update clj-rbac-client to 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.9]
+
+- Update clj-rbac-client to add `subject` to the consumer service protocol
+
 ## [1.7.8]
 
 - Update trapperkeeper-status to 1.1.0

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "2.1.2")
 (def tk-metrics-version "1.1.0")
 (def logback-version "1.1.9")
-(def rbac-client-version "0.8.2")
+(def rbac-client-version "0.8.3")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "1.7.9-SNAPSHOT"


### PR DESCRIPTION
This updates clj-rbac-client to 0.8.3 to add the `subject` method to
the consumer service, and the remote client implementation of it.