### PR TITLE
(maint) update jdbc-util to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.10]
+
+- update jdbc-util to 1.2.2, and java-jdbc to 0.7.7
+
 ## [1.7.9]
 
 - Update clj-rbac-client to add `subject` to the consumer service protocol

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                          [org.clojure/tools.nrepl "0.2.6"]
                          [org.clojure/tools.macro "0.1.5"]
                          [org.clojure/java.classpath "0.2.3"]
-                         [org.clojure/java.jdbc "0.7.5"]
+                         [org.clojure/java.jdbc "0.7.7"]
                          [org.clojure/java.jmx "0.3.1"]
                          [org.clojure/core.async "0.2.391"]
                          [org.clojure/core.cache "0.6.5"]
@@ -93,7 +93,7 @@
                          [prismatic/schema "1.1.1"]
 
                          [puppetlabs/http-client "0.9.0"]
-                         [puppetlabs/jdbc-util "1.1.1"]
+                         [puppetlabs/jdbc-util "1.2.2"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "0.9.1"]
                          [puppetlabs/clj-ldap "0.1.6"]


### PR DESCRIPTION
This updates jdbc-util to 1.2.2 which changes the way the deferred
init and migrations are handled to make them more robust.  It includes
a new version of migratus and java.jdbc.