### PR TITLE
(PE-24735) update clj-rbac-client to 0.9.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "2.1.2")
 (def tk-metrics-version "1.1.0")
 (def logback-version "1.2.3")
-(def rbac-client-version "0.9.0")
+(def rbac-client-version "0.9.1")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "2.0.7-SNAPSHOT"


### PR DESCRIPTION
This updates rbac-client to 0.9.1 to bring in a new function into the RBAC consumer service.