### PR TITLE
(PE-24859) update jdbc-util to 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.11]
+
+- update jdbc-util to 1.2.3 to prevent partial migration failure
+
 ## [1.7.10]
 
 - update jdbc-util to 1.2.2, and java-jdbc to 0.7.7

--- a/project.clj
+++ b/project.clj
@@ -93,7 +93,7 @@
                          [prismatic/schema "1.1.1"]
 
                          [puppetlabs/http-client "0.9.0"]
-                         [puppetlabs/jdbc-util "1.2.2"]
+                         [puppetlabs/jdbc-util "1.2.3"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "0.9.1"]
                          [puppetlabs/clj-ldap "0.1.6"]


### PR DESCRIPTION
This updates jdbc-util to 1.2.3 to deal with some issues seen in testing.

Specifically, a partial migration/deadlock can occur if the pool is closed
while the migrations are running.  This updates the close-after-ready behavior
to specifically wait for a safe point prior to closing the pool.