### PR TITLE
(maint) Update schema and compress to latest z versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.x]
+
+- Update `prismatic/schema` from 1.1.1 to 1.1.9.
+
 ## [2.1.1]
 
 - update clj-ldap to 0.2.0 to bring in some new versions of dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [2.1.x]
 
+- Update `org.apache.commons/commons-compress` from 1.8 to 1.17.
 - Update `prismatic/schema` from 1.1.1 to 1.1.9.
 
 ## [2.1.1]

--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]
                          [org.apache.commons/commons-exec "1.3"]
-                         [org.apache.commons/commons-compress "1.8"]
+                         [org.apache.commons/commons-compress "1.17"]
                          [org.apache.commons/commons-lang3 "3.4"]
                          [org.apache.httpcomponents/httpclient  "4.5.2"]
                          [org.apache.httpcomponents/httpcore  "4.4.5"]

--- a/project.clj
+++ b/project.clj
@@ -90,7 +90,7 @@
                          [org.postgresql/postgresql "42.2.2"]
 
                          [prismatic/plumbing "0.4.2"]
-                         [prismatic/schema "1.1.1"]
+                         [prismatic/schema "1.1.9"]
 
                          [puppetlabs/http-client "0.9.0"]
                          [puppetlabs/jdbc-util "1.2.3"]


### PR DESCRIPTION
This eliminates the two remaining places where puppetdb was ahead of clj-parent 2.1.