### PR TITLE
(maint) update clj-parent and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.12]
+
+- update clj-ldap to 0.2.0 to bring in new versions of dependencies
+
 ## [1.7.11]
 
 - update jdbc-util to 1.2.3 to prevent partial migration failure

--- a/project.clj
+++ b/project.clj
@@ -96,7 +96,7 @@
                          [puppetlabs/jdbc-util "1.2.3"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "0.9.1"]
-                         [puppetlabs/clj-ldap "0.1.6"]
+                         [puppetlabs/clj-ldap "0.2.0"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]
                          [puppetlabs/trapperkeeper ~tk-version]


### PR DESCRIPTION
This updates clj-parent to bring in new versions of dependencies it
uses.  It also updates the changelog to reflect those changes.