### PR TITLE
(maint) update clj-ldap to 0.2.0 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.1]
+
+- update clj-ldap to 0.2.0 to bring in some new versions of dependencies.
+
 ## [2.1.0]
 
 - Update `trapperkeeper-webserver-jetty9` to 2.2.0

--- a/project.clj
+++ b/project.clj
@@ -96,7 +96,7 @@
                          [puppetlabs/jdbc-util "1.2.3"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "1.0.0"]
-                         [puppetlabs/clj-ldap "0.1.6"]
+                         [puppetlabs/clj-ldap "0.2.0"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]
                          [puppetlabs/trapperkeeper ~tk-version]


### PR DESCRIPTION
This updates clj-parent to bring in new versions of dependencies it
uses. It also updates the changelog to reflect those changes.