### PR TITLE
(maint) Add medley

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -88,6 +88,7 @@
                          [org.ow2.asm/asm-all "5.0.3"]
                          [honeysql "0.6.3"]
                          [org.postgresql/postgresql "42.2.2"]
+                         [medley "1.0.0"]
 
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.9"]


### PR DESCRIPTION
Medley is a dependency of compojure, which is a dependency of comidi. Probably all of our webservice require it transitively. Puppet Server is currently pulling in 0.7.x and the jump between it and 1.0 should contain no breaking changes. However the 0.6 and 0.7 bumps contained breaking changes according to their docs https://github.com/weavejester/medley#breaking-changes so be aware when upgrading.

This upgrade is needed to remove:
```
WARNING: boolean? already refers to: #'clojure.core/boolean? in namespace: medley.core, being replaced by: #'medley.core/boolean?
```

/cc @MikaelSmith @steveax @jonathannewman @rbrw (no idea who all should be pinged on this)