### PR TITLE
(PDB-3942) Update metrics-clojure to 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.2.1]
+
+- Update `metrics-clojure` from 2.6.1 to 2.10.0
+
 ## [2.2.0]
 
 - Update `org.apache.commons/commons-compress` from 1.8 to 1.17

--- a/project.clj
+++ b/project.clj
@@ -84,7 +84,7 @@
                          [trptcolin/versioneer "0.2.0"]
                          [io.dropwizard.metrics/metrics-core ~dropwizard-metrics-version]
                          [io.dropwizard.metrics/metrics-graphite ~dropwizard-metrics-version]
-                         [metrics-clojure "2.6.1"]
+                         [metrics-clojure "2.10.0"]
                          [org.ow2.asm/asm-all "5.0.3"]
                          [honeysql "0.6.3"]
                          [org.postgresql/postgresql "42.2.2"]


### PR DESCRIPTION
This is necessary due to the use of dropwizards 3.2.2. As you can see
from metrics-clojure/metrics-clojure@f5b2e92 when upgrading to 3.2.2
metrics-clojure needed a change to `time-fn!` and since clj-parent
already uses dropwizards 3.2.2, using the old version of
metrics-clojure was causing `time-fn!` to break.