### PR TITLE
(maint) update clj-http-client to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.13]
+
+- update clj-http client to 1.0.0 to take advantage of the new persistent client options
+
 ## [1.7.12]
 
 - update clj-ldap to 0.2.0 to bring in new versions of dependencies

--- a/project.clj
+++ b/project.clj
@@ -92,7 +92,7 @@
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.1"]
 
-                         [puppetlabs/http-client "0.9.0"]
+                         [puppetlabs/http-client "1.0.0"]
                          [puppetlabs/jdbc-util "1.2.3"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "0.9.1"]


### PR DESCRIPTION
clj-http-client fixes an issue were malformed content-type headers
could result in a blank response.  It also adds two configuration
values that can be used for persistent clients to allow the total
number of connections allowed through the client, as well as the
total number of connections per route through the client.