### PR TITLE
(maint) update tk-scheduler to 1.0.0 and prepare for 2.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.3.4]
+
+- update trapperkeeper-scheduler to 1.0.0 to use the quartz scheduler instead of at-at internally.
+
 ## [2.3.3]
 
 - update ring-middleware to 1.0.1 for better logging of uncaught exceptions

--- a/project.clj
+++ b/project.clj
@@ -107,7 +107,7 @@
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version]
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version :classifier "test"]
                          [puppetlabs/trapperkeeper-authorization "0.7.0"]
-                         [puppetlabs/trapperkeeper-scheduler "0.1.0"]
+                         [puppetlabs/trapperkeeper-scheduler "1.0.0"]
                          [puppetlabs/trapperkeeper-status "1.1.0"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.1.0"]
                          [puppetlabs/structured-logging "0.2.0"]


### PR DESCRIPTION
This updates the trapperkeeper-scheduler to version 1.0.0 to replace
the use of at-at with the quartz scheduler.

Update changelog for 2.3.4 release