### PR TITLE
(maint) update clj-rbac client and prepare for 1.7.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.16]
+
+- update clj-rbac-client to 0.8.4 to increase the maximum number of simultaneous connections
+
 ## [1.7.15]
 
 - update ring-middleware to 1.0.1 for better logging of uncaught exceptions

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "2.1.2")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.1.9")
-(def rbac-client-version "0.8.3")
+(def rbac-client-version "0.8.4")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "1.7.16-SNAPSHOT"


### PR DESCRIPTION
This updates clj-rbac-client to 0.8.4 to allow more simultaneous connections to rbac and activity service.  It also updates the changelog in preparation for a release.