### PR TITLE
(maint) update clj-rbac-client to 0.9.2 and prepare for 2.3.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.3.5]
+
+- update clj-rbac-client to 0.9.2 to increase the number of concurrent request the client will make to activity and rbac services
+
 ## [2.3.4]
 
 - update trapperkeeper-scheduler to 1.0.0 to use the quartz scheduler instead of at-at internally.

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "2.3.0")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.2.3")
-(def rbac-client-version "0.9.1")
+(def rbac-client-version "0.9.2")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "2.3.5-SNAPSHOT"


### PR DESCRIPTION
This updates clj-rbac-client to 0.9.2, which increases the number of simultaneous requests to rbac and activity services from 2 to 20 each.

It also updates the CHANGELOG in preparation of the 2.3.5 release.