### PR TITLE
(TK-472) Update tk-jetty9 to 2.3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.8.0")
 (def ks-version "2.5.2")
 (def tk-version "1.5.6")
-(def tk-jetty-version "2.1.2")
+(def tk-jetty-version "2.3.0")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.1.9")
 (def rbac-client-version "0.8.4")


### PR DESCRIPTION
This update brings in a newer version of Jetty, which has fixes for some
security vulnerabilities.