### PR TITLE
(maint) update tk-scheduler, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.3.6]
+
+- update trapperkeeper-scheduler to 1.0.1 to exclude c3p0 dependency
+
 ## [2.3.5]
 
 - update clj-rbac-client to 0.9.2 to increase the number of concurrent request the client will make to activity and rbac services

--- a/project.clj
+++ b/project.clj
@@ -107,7 +107,7 @@
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version]
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version :classifier "test"]
                          [puppetlabs/trapperkeeper-authorization "0.7.0"]
-                         [puppetlabs/trapperkeeper-scheduler "1.0.0"]
+                         [puppetlabs/trapperkeeper-scheduler "1.0.1"]
                          [puppetlabs/trapperkeeper-status "1.1.0"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.1.0"]
                          [puppetlabs/structured-logging "0.2.0"]


### PR DESCRIPTION
Updates to trapperkeeper-scheduler 1.0.1 and updates the changelog.