### PR TITLE
(PE-25389) update tk-scheduler to 1.1.0, prepare for 2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.4.0]
+
+- update trapperkeeper-scheduler to 1.1.0 which adds support for interval based scheduling
+
 ## [2.3.6]
 
 - update trapperkeeper-scheduler to 1.0.1 to exclude c3p0 dependency

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 (def rbac-client-version "0.9.2")
 (def dropwizard-metrics-version "3.2.2")
 
-(defproject puppetlabs/clj-parent "2.3.7-SNAPSHOT"
+(defproject puppetlabs/clj-parent "2.4.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.

--- a/project.clj
+++ b/project.clj
@@ -107,7 +107,7 @@
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version]
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version :classifier "test"]
                          [puppetlabs/trapperkeeper-authorization "0.7.0"]
-                         [puppetlabs/trapperkeeper-scheduler "1.0.1"]
+                         [puppetlabs/trapperkeeper-scheduler "1.1.0"]
                          [puppetlabs/trapperkeeper-status "1.1.0"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.1.0"]
                          [puppetlabs/structured-logging "0.2.0"]


### PR DESCRIPTION
This updates tk-scheduler to 1.1.0 that adds a new interface for interspaced jobs.  

It also updates project.clj and CHANGELOG in prep for a 2.4.0 release.