### PR TITLE
(TK-475) Update rbac client to public version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [2.4.1]
 
-- update trapperkeeper-webserver-jetty9 to 2.3.1 which suppresses Jetty's default behavior of reporting it's version in the server headers.
+- update trapperkeeper-webserver-jetty9 to 2.3.1 which suppresses Jetty's default behavior of reporting its version in the server headers.
+- update clj-rbac-client to 0.9.3, the first public release of the library
 
 ## [2.4.0]
 

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "2.3.1")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.2.3")
-(def rbac-client-version "0.9.2")
+(def rbac-client-version "0.9.3")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "2.4.1-SNAPSHOT"


### PR DESCRIPTION
As part of integrating the rbac client into tk-auth, we needed to open
source the library. This commit bumps the version of clj-rbac-client to
the new public release.