### PR TITLE
Bump rbac-client to 0.9.4 for new auth middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.4.2]
+
+- update clj-rbac-client to 0.9.4 for wrap-cert-only-access authentication middleware.
+
 ## [2.4.1]
 
 - update trapperkeeper-webserver-jetty9 to 2.3.1 which suppresses Jetty's default behavior of reporting its version in the server headers.

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "2.3.1")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.2.3")
-(def rbac-client-version "0.9.3")
+(def rbac-client-version "0.9.4")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "2.4.2-SNAPSHOT"


### PR DESCRIPTION
Adds wrap-cert-only-access authentication middleware via rbac-client 0.9.4 and prepares clj-parent 2.4.2 release.