### PR TITLE
(maint) Update dynapath to 1.0.0 and Clojure to 1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.5.0]
+
+- update dynapath to allow compilation on jdk8 but operation on later java versions.
+
 ## [2.4.2]
 
 - update clj-rbac-client to 0.9.4 for wrap-cert-only-access authentication middleware.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [2.5.0]
 
+- update clojure to 1.10.0.
 - update dynapath to allow compilation on jdk8 but operation on later java versions.
 
 ## [2.4.2]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def clj-version "1.9.0")
+(def clj-version "1.10.0")
 (def ks-version "2.5.2")
 (def tk-version "1.5.6")
 (def tk-jetty-version "2.3.1")

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 (def rbac-client-version "0.9.4")
 (def dropwizard-metrics-version "3.2.2")
 
-(defproject puppetlabs/clj-parent "2.4.3-SNAPSHOT"
+(defproject puppetlabs/clj-parent "2.5.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.
@@ -80,7 +80,7 @@
                          [beckon "0.1.1"]
                          [hiccup "1.0.5"]
                          [liberator "0.15.2"]
-                         [org.tcrawley/dynapath "0.2.4"]
+                         [org.tcrawley/dynapath "1.0.0"]
                          [trptcolin/versioneer "0.2.0"]
                          [io.dropwizard.metrics/metrics-core ~dropwizard-metrics-version]
                          [io.dropwizard.metrics/metrics-graphite ~dropwizard-metrics-version]

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                          [org.clojure/java.classpath "0.2.3"]
                          [org.clojure/java.jdbc "0.7.7"]
                          [org.clojure/java.jmx "0.3.4"]
-                         [org.clojure/core.async "0.4.474"]
+                         [org.clojure/core.async "0.4.490"]
                          [org.clojure/core.cache "0.7.1"]
                          [org.clojure/core.memoize "0.7.1"]
                          [org.clojure/tools.reader "1.2.1"]


### PR DESCRIPTION
This was updated in kitchensink when doing the Java 9+ work but because
it wasn't updated in clj-parent it doesn't look like most projects were
actually using the dependency at that version.

The previous version of dynapath (0.2.4) would decide whether or not it
could use the APIs exposed in Java 8 and if not only use the ones
exposed in Java 9+. It would make that decision at compile time however
so projects AOTed on Java 8 could not be ran on new Java versions. 0.2.5
moved the check to runtime rather than compile time, and 1.0.0 removes
the check completely and only extends the classes exposed in 9+.