### PR TITLE
(TK-474) Update tk-auth to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.20]
+
+- update trapperkeeper-authorization to 1.0.0, which brings in the ability to specify rules based on RBAC permissions. NOTE: this is not a breaking update.
+
 ## [1.7.19]
 
 - update jackson-databind to 2.9.8, fixing several security issues

--- a/project.clj
+++ b/project.clj
@@ -105,7 +105,7 @@
                          [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version :classifier "test"]
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version]
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version :classifier "test"]
-                         [puppetlabs/trapperkeeper-authorization "0.7.0"]
+                         [puppetlabs/trapperkeeper-authorization "1.0.0"]
                          [puppetlabs/trapperkeeper-scheduler "0.1.0"]
                          [puppetlabs/trapperkeeper-status "1.1.0"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.1.0"]


### PR DESCRIPTION
This version of tk-auth adds the ability to specify rules based on RBAC
permissions. It is NOT a breaking change; we moved the library to 1.0.0
to establish clear semver for tk-auth from here on out.