### PR TITLE
(maint) Update nrepl to latest supported

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                          [org.clojure/clojurescript "1.7.122"]
                          [org.clojure/tools.logging "0.4.0"]
                          [org.clojure/tools.cli "0.3.6"]
-                         [org.clojure/tools.nrepl "0.2.13"]
+                         [nrepl "0.5.3"]
                          [org.clojure/tools.macro "0.1.5"]
                          [org.clojure/java.classpath "0.2.3"]
                          [org.clojure/java.jdbc "0.7.7"]


### PR DESCRIPTION
org.clojure/tools.nrepl is no longer the supported nrepl. Switch to
nrepl/nrepl 0.5.3 instead. Newer versions of CIDER require at least
nrepl 0.4.4.