### PR TITLE
(SERVER-2421) Downgrade dynapath to 0.2.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -80,7 +80,7 @@
                          [beckon "0.1.1"]
                          [hiccup "1.0.5"]
                          [liberator "0.15.2"]
-                         [org.tcrawley/dynapath "1.0.0"]
+                         [org.tcrawley/dynapath "0.2.5"]
                          [trptcolin/versioneer "0.2.0"]
                          [io.dropwizard.metrics/metrics-core ~dropwizard-metrics-version]
                          [io.dropwizard.metrics/metrics-graphite ~dropwizard-metrics-version]


### PR DESCRIPTION
Previously, we upgraded dynapath to 1.0.0 to resolve an issue in
version 0.2.4 that code AOT-ed on Java 8 was not able to start on
Java 9+.

In 0.2.5 dynapath fixed the bug that was the issue - to detect and only
extend those classes visible in the version of Java at runtime rather
than compile time.

In the next version, 1.0.0, dynapath removed the extensions to classes not
exposed in Java 9+ altogether.

It seemed wise to upgrade dynapath to 1.0.0 and initial testing found no
regressions. However in acceptance testing we've found a regression, the
trapperkeeper reloading (and specifically how we extend the classpath to
find the Facter jar) broke in Java 8 when only using the Java 9+ APIs.

With additional investigation it seems that reloading in Puppet Server
has always been broken in Java versions 9+, and is an acceptable state
temporarily while we work to improve our (unofficial) support for Java
9+.

Consequently, this patch downgrades us from 1.0.0 (resolving the
regression in Java 8 reloading), to 0.2.5 (which resolves the failure
to start AOTed code in 9+), leaving a known (and pre-existing) issue
when reloading Server in 9+ (see SERVER-2423).