### PR TITLE
[DNM] (maint) Update snakeyaml to latest (1.23)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                          [com.fasterxml.jackson.core/jackson-core "2.9.4"]
                          [com.fasterxml.jackson.core/jackson-databind "2.9.8"]
                          [com.fasterxml.jackson.module/jackson-module-afterburner "2.9.4"]
-                         [org.yaml/snakeyaml "1.18"]
+                         [org.yaml/snakeyaml "1.23"]
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]
                          [org.apache.commons/commons-exec "1.3"]


### PR DESCRIPTION
JRuby (and consequently Puppet Server) is tightly coupled to snakeyaml
implementations and bumping one sometimes means bumping the other. We
(Puppet Server) want to bump JRuby and consequently snakeyaml.

This version bump seems to have Java 9+ work, removal of Java <7
support, and some api changes (especially around Scalars).

This search: ["lang:clojure snakeyaml"](https://github.com/search?l=Clojure&q=org%3Apuppetlabs+snakeyaml&type=Code)
indicates classifier and console middleware also use snakeyaml.