### PR TITLE
(SERVER-2431) Update jvm-ssl-utils to 1.0.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -95,7 +95,7 @@
                          [puppetlabs/http-client "1.0.0"]
                          [puppetlabs/jdbc-util "1.2.3"]
                          [puppetlabs/typesafe-config "0.1.5"]
-                         [puppetlabs/ssl-utils "1.0.1"]
+                         [puppetlabs/ssl-utils "1.0.2"]
                          [puppetlabs/clj-ldap "0.2.0"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]


### PR DESCRIPTION
This version contains an update to BouncyCastle, fixing some security
vulnerabilities.