### PR TITLE
(PCP-862) Update tk-webserver-jetty9 to 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.6.4]
+
+- update trapperkeeper-webserver-jetty9 to 2.4.1 which only disconnects if the session is still open
+
 ## [2.6.3]
 
 - update trapperkeeper-webserver-jetty9 to 2.4.0 which adds disconnect function for websockets

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.10.0")
 (def ks-version "2.5.2")
 (def tk-version "1.5.6")
-(def tk-jetty-version "2.4.0")
+(def tk-jetty-version "2.4.1")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.2.3")
 (def rbac-client-version "0.9.4")


### PR DESCRIPTION
This updates trapperkeeper-webserver-jetty9 to 2.4.1 which only disconnects a connection if the session is not null