### PR TITLE
(PCP-862) Bump tk-webserver-jetty9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.22]
+
+- update trapperkeeper-webserver-jetty9 to 2.4.1 which includes a `disconnect` function for disconnecting websocket connections
+
 ## [1.7.21]
 
 - Update jvm-ssl-utils to 1.0.2, which updates BouncyCastle, fixing a security issue

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.8.0")
 (def ks-version "2.5.2")
 (def tk-version "1.5.6")
-(def tk-jetty-version "2.3.1")
+(def tk-jetty-version "2.4.1")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.1.9")
 (def rbac-client-version "0.8.4")


### PR DESCRIPTION
This bumps trapperkeeper-webserver-jetty9 to 2.4.1 which includes a `disconnect` function to disconnect from websocket connections