### PR TITLE
(maint) Bump rbac-client to publicly published version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "2.4.1")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.1.9")
-(def rbac-client-version "0.8.4")
+(def rbac-client-version "0.9.4")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "1.7.23-SNAPSHOT"


### PR DESCRIPTION
This was open sourced for trapperkeeper-authorization use and we need to
use a version from after it was open sourced in puppetserver. This has
only minor changes.