### PR TITLE
(orch-2282) Add support for nrepl/nrepl in parallel w/ org.clojure/tools.nrepl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.7.24]
+
+- add nrepl/nrepl 0.6.0 to move to mainline development for nrepl
+- left org.clojure/tools.nrepl to maintain backwards compatibility
+
 ## [1.7.22]
 
 - update trapperkeeper-webserver-jetty9 to 2.4.1 which includes a `disconnect` function for disconnecting websocket connections

--- a/project.clj
+++ b/project.clj
@@ -58,6 +58,7 @@
 
                          [com.taoensso/nippy "2.10.0"]
 
+                         [nrepl/nrepl "0.6.0"]
                          [bidi "2.1.3"]
                          [clj-time "0.11.0"]
                          [circleci/clj-yaml "0.5.5"]


### PR DESCRIPTION
This adds support for the mainline nrepl project and maintains backwards
compatibility with the legacy version living in org.clojure. This is part of a
series of changes to support nrepl/nrepl in trapperkeeper.
