### PR TITLE
(SERVER-2522) Add analytics-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.6.5]
+
+- add the analytics client to the managed dependencies
+
 ## [2.6.4]
 
 - update trapperkeeper-webserver-jetty9 to 2.4.1 which only disconnects if the session is still open

--- a/project.clj
+++ b/project.clj
@@ -119,6 +119,7 @@
                          [puppetlabs/cljs-dashboard-widgets "0.1.0"]
                          [puppetlabs/rbac-client ~rbac-client-version]
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
+                         [puppetlabs/analytics-client "1.0.1"]
                          ]
 
   :dependencies [[org.clojure/clojure]]


### PR DESCRIPTION
The analytics-client was recently open-sourced, so this commit pulls it
into clj-parent, to help managing its version across projects easier.