### PR TITLE
(ORCH-2282) Update to tk 2.0.0 as part of supporting nrepl/nrepl

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.8.0")
 (def ks-version "2.5.2")
-(def tk-version "1.5.6")
+(def tk-version "2.0.0")
 (def tk-jetty-version "2.4.1")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.1.9")


### PR DESCRIPTION
This is part of ongoing work to move to a more current version of nrepl; this involves changes to clj-parent, trapperkeeper, orchestrator and pe-orchestration-services.

This should not be merged until after https://github.com/puppetlabs/trapperkeeper/pull/280 is merged.