### PR TITLE
(maint) Update trapperkeeper to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.25]
+
+- update trapperkeeper to fix a bug with error handling
+
 ## [1.7.24]
 
 - add nrepl/nrepl 0.6.0 to move to mainline development for nrepl

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.8.0")
 (def ks-version "2.5.2")
-(def tk-version "2.0.0")
+(def tk-version "2.0.1")
 (def tk-jetty-version "2.4.1")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.1.9")


### PR DESCRIPTION
This update contains better error surfacing.