### PR TITLE
(maint) replace broken snapshot deploy repo

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -132,4 +132,4 @@
                                      :username :env/clojars_jenkins_username
                                      :password :env/clojars_jenkins_password
                                      :sign-releases false}]
-                        ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]])
+                        ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/list/clojure-snapshots__local/"]])


### PR DESCRIPTION
Snapshots should publish to artifactory, not the old Nexus server