### PR TITLE
(PE-26836) update clj-ldap to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.27[
+
+- update clj-ldap to 0.2.1 to address an issue with base-64 encoded names
+
 ## [1.7.26]
 
 - update trapperkeeper to fix a bug with error handling

--- a/project.clj
+++ b/project.clj
@@ -97,7 +97,7 @@
                          [puppetlabs/jdbc-util "1.2.3"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "1.0.2"]
-                         [puppetlabs/clj-ldap "0.2.0"]
+                         [puppetlabs/clj-ldap "0.2.1"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]
                          [puppetlabs/trapperkeeper ~tk-version]


### PR DESCRIPTION
This addresses an issue where names with extended characters would
be displayed as base64 encoded strings instead of the name itself.