### PR TITLE
(maint) Replace me.raynes/fs with clj-commons/fs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -65,7 +65,7 @@
                          [circleci/clj-yaml "0.5.5"]
                          [clj-stacktrace "0.2.8"]
                          [com.zaxxer/HikariCP "2.7.4"]
-                         [me.raynes/fs "1.4.6"]
+                         [clj-commons/fs "1.5.1"]
                          [instaparse "1.4.1"]
                          [slingshot "0.12.2"]
                          [cheshire "5.8.0"]


### PR DESCRIPTION
me.raynes/fs is unmaintained, though the project has been forked and
taken over by the clj-commons community. The API has not changed but
they are reactively updating dependencies as needed.

When we upgraded apache's commons/compress to 1.18 we broke raynes'
fs because it dependend on compress bringing in xz. This is only
apparent when require me.raynes.fs.compression.

Because this exposes the same namespaces and vars as raynes' I've chosen
to replace raynes with it. Otherwise which project was loaded would be
unspecified.

This will require all consumers to update their dependencies from
`[me.raynes/fs]` to `[clj-commons/fs]` but should require zero code
changes.