### PR TITLE
(maint) merge 1.7.x -> master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.27] (not present in 2.x, 3.x version until here)
+
+- update clj-ldap to 0.2.1 to address an issue with base-64 encoded names
+
 ## [3.1.1]
 
 - update clj-shell-utils to version built with openjdk8

--- a/project.clj
+++ b/project.clj
@@ -99,7 +99,7 @@
                          [puppetlabs/jdbc-util "1.2.4"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "2.0.0"]
-                         [puppetlabs/clj-ldap "0.2.0"]
+                         [puppetlabs/clj-ldap "0.2.1"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]
                          [puppetlabs/trapperkeeper ~tk-version]


### PR DESCRIPTION
This merges in a change to clj-ldap that fixes an issue with incorrect base64 encoding of parameters that didn't need to be encoded.