### PR TITLE
(maint) Include FIPS compatible ssl-utils

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -98,7 +98,7 @@
                          [puppetlabs/http-client "1.0.0"]
                          [puppetlabs/jdbc-util "1.2.4"]
                          [puppetlabs/typesafe-config "0.1.5"]
-                         [puppetlabs/ssl-utils "2.0.0"]
+                         [puppetlabs/ssl-utils "3.0.1"]
                          [puppetlabs/clj-ldap "0.2.1"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]


### PR DESCRIPTION
This is a breaking change that requires consumers of ssl-utils to
specify their own version of bouncycastle (which was previously brought
in for them). They are now also free to choose between FOSS and FIPS
bouncy castle versions.