### PR TITLE
(maint) Take up trapperkeeper-webserver-jetty9 3.0.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.10.1")
 (def ks-version "2.5.2")
 (def tk-version "2.0.1")
-(def tk-jetty-version "2.4.1")
+(def tk-jetty-version "3.0.1")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.2.3")
 (def rbac-client-version "0.9.4")


### PR DESCRIPTION
This is the first release in the TK Jetty 3.x series and includes
updated cipher suite defaults and the removal of the so-linger-seconds
option.