### PR TITLE
(TK-482) Use clj-commons/clj-yaml instead of circleci

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -62,7 +62,7 @@
                          [nrepl/nrepl "0.6.0"]
                          [bidi "2.1.3"]
                          [clj-time "0.11.0"]
-                         [circleci/clj-yaml "0.5.5"]
+                         [clj-commons/clj-yaml "0.7.0"]
                          [clj-stacktrace "0.2.8"]
                          [com.zaxxer/HikariCP "2.7.4"]
                          [clj-commons/fs "1.5.1"]


### PR DESCRIPTION
clj-commons has taken over ownership of clj-yaml and it behooves us to
use their maintained version of it.

This replaces circleci's version to require users to upgrade their
dependencies since having both artifact groups causes undefined behavior
when loading (they provide the same namespaces).

This is the same approach to how we are upgrading me.raynes/fs.