### PR TITLE
(TK-484) Update tk-jetty9 to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.2.0]
+
+- Update trapperkeeper-webserver-jetty9 to 4.0.0, which further restricts
+  the available cipher suites.
+
 ## [4.1.1]
 
 - (SERVER-2193) Update jruby-utils to 2.2.0, which adds an API for getting

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
 (def clj-version "1.10.1")
 (def ks-version "3.0.0")
 (def tk-version "3.0.0")
-(def tk-jetty-version "3.0.2")
+(def tk-jetty-version "4.0.0")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.2.3")
 (def rbac-client-version "0.9.4")
 (def dropwizard-metrics-version "3.2.2")
 
-(defproject puppetlabs/clj-parent "4.1.2-SNAPSHOT"
+(defproject puppetlabs/clj-parent "4.2.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.


### PR DESCRIPTION
This update further restricts the default list of available cipher
suites.