### PR TITLE
(PE-27018) update jdbc-utl to 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [1.7.27[
+## [1.7.28]
+
+- update jdbc-util to address issues with scheme-migration table being creaated on replicas
+
+## [1.7.27]
 
 - update clj-ldap to 0.2.1 to address an issue with base-64 encoded names
 

--- a/project.clj
+++ b/project.clj
@@ -94,7 +94,7 @@
                          [prismatic/schema "1.1.1"]
 
                          [puppetlabs/http-client "1.0.0"]
-                         [puppetlabs/jdbc-util "1.2.3"]
+                         [puppetlabs/jdbc-util "1.2.5"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "1.0.2"]
                          [puppetlabs/clj-ldap "0.2.1"]


### PR DESCRIPTION
This updates jdcb-util to 1.2.5 to address issues with replicas creating
the migration table, when it is assumed that replicas will be a read-only
relationship with the database.

Also update changelog in preparation for release.