### PR TITLE
(PE-26658) update clj-http-client & tk-jetty9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [4.2.4]
+
+- update clj-http-client to 1.1.2 to support running in fully restricted
+  FIPS mode.
+- update trapperkeeper-webserver-jetty9 to 4.0.1 to support running in fully
+  restricted FIPS mode. This will also install the SLF4JBridgeHandler at runtime, 
+  which will forward all java.util.logging calls to SLF4J automatically, meaning
+  they can be controlled via the logback configuration files (logback.xml, etc)
+
+## [4.2.3]
+
+- Adds jul-to-slf4j dependency definition for forwarding java.util.logging messages
+  to SLF4J. The bouncycastle FIPS provider logs exclusively through java.util.logging.
+- Adds httpasyncclient version, as opposed to specifying it directly in clj-http-client.
+
+## [4.2.2]
+
+- update bc-fips to version 1.0.2, which is certified for use with JDK 11.
+- adds bctls-fips to support TLS transactions via the bouncycastle provider.
+
 ## [4.2.1]
 ## [2.7.1]
 ## [1.7.28]

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.10.1")
 (def ks-version "3.0.0")
 (def tk-version "3.0.0")
-(def tk-jetty-version "4.0.0")
+(def tk-jetty-version "4.0.1")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.2.3")
 (def rbac-client-version "0.9.4")
@@ -97,7 +97,7 @@
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.9"]
 
-                         [puppetlabs/http-client "1.1.1"]
+                         [puppetlabs/http-client "1.1.2"]
                          [puppetlabs/jdbc-util "1.2.5"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "3.0.4"]


### PR DESCRIPTION
Updates to the versions that properly support FIPS