### PR TITLE
(PE-27497) Update tk-filesystem-watcher to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.30]
+
+- update tk-filesystem-watcher to 1.1.1, which has improved error handling
+
 ## [1.7.29]
 
 - update jackson-xml to 2.10 (see PE-27458)

--- a/project.clj
+++ b/project.clj
@@ -109,7 +109,7 @@
                          [puppetlabs/trapperkeeper-authorization "1.0.0"]
                          [puppetlabs/trapperkeeper-scheduler "0.1.0"]
                          [puppetlabs/trapperkeeper-status "1.1.0"]
-                         [puppetlabs/trapperkeeper-filesystem-watcher "1.1.0"]
+                         [puppetlabs/trapperkeeper-filesystem-watcher "1.1.1"]
                          [puppetlabs/structured-logging "0.2.0"]
                          [puppetlabs/ring-middleware "1.0.1"]
                          [puppetlabs/dujour-version-check "0.2.1"]


### PR DESCRIPTION
This version has improved error handling.