### PR TITLE
(SERVER-2360) Update jruby-utils to 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.2.7]
+
+- update jruby-utils to 2.3.1 to support usage of the multithreaded key for JRubyConfig
+
 ## [4.2.6]
 
 - updates tk-filesystem-watcher to 1.2.1, which has better error handling

--- a/project.clj
+++ b/project.clj
@@ -125,7 +125,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.0.2"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "2.2.0"]
+                         [puppetlabs/jruby-utils "2.3.1"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
This adds support for the multithreaded key for JRubyConfig.