### PR TITLE
(SERVER-2674) Update jruby-utils to 2.3.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -125,7 +125,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.0.2"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "2.3.1"]
+                         [puppetlabs/jruby-utils "2.3.2"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
This update downgrades JRuby to 9.2.8.0 to avoid a bug in 9.2.9.0.