### PR TITLE
(PDB-4255) update taoensso libs to remove warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -59,7 +59,8 @@
                          [commons-io "2.4"]
                          [joda-time "2.8.2"]
 
-                         [com.taoensso/nippy "2.10.0"]
+                         [com.taoensso/nippy "2.14.0"]
+                         [com.taoensso/encore "2.115.0"]
 
                          [nrepl/nrepl "0.6.0"]
                          [bidi "2.1.3"]


### PR DESCRIPTION
Update taoensso/nippy and taoensso/encore to remove warnings:

    WARNING: pos-int? already refers to: #'clojure.core/pos-int? in namespace: taoensso.encore, being replaced by: #'taoensso.encore/pos-int?
    WARNING: bytes? already refers to: #'clojure.core/bytes? in namespace: taoensso.encore, being replaced by: #'taoensso.encore/bytes?