### PR TITLE
(PE-27189) update http-client to 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.2.11]
+
+- update http-client to 1.1.3 to remove ambiguity around RequestObject construction under java 11
+
 ## [4.2.10]
 
 - update com.taoensso/nippy to 2.14.0 in order to address some clojure warnings

--- a/project.clj
+++ b/project.clj
@@ -98,7 +98,7 @@
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.9"]
 
-                         [puppetlabs/http-client "1.1.2"]
+                         [puppetlabs/http-client "1.1.3"]
                          [puppetlabs/jdbc-util "1.2.5"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "3.0.4"]


### PR DESCRIPTION
This updates http-client to 1.1.3, which includes improvements to
prevent clojure being unable to resolve symbols due to class loader
changes in java 11.  Specifically when service were reloaded, some
were unable to resolve the correct class constructor methods.  The
change in 1.1.3 removes that ambiguity with type hints.

In a separate commit, the changelog is updated in preparation for a new release.