### PR TITLE
(PE-27497) Bump tk-fs-watcher to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [1.7.31]
+- update tk-filesystem-watcher to ignore lock directories that disappear when registering.
+
 ## [1.7.30]
 
 - update tk-filesystem-watcher to 1.1.1, which has improved error handling

--- a/project.clj
+++ b/project.clj
@@ -109,7 +109,7 @@
                          [puppetlabs/trapperkeeper-authorization "1.0.0"]
                          [puppetlabs/trapperkeeper-scheduler "0.1.0"]
                          [puppetlabs/trapperkeeper-status "1.1.0"]
-                         [puppetlabs/trapperkeeper-filesystem-watcher "1.1.1"]
+                         [puppetlabs/trapperkeeper-filesystem-watcher "1.1.2"]
                          [puppetlabs/structured-logging "0.2.0"]
                          [puppetlabs/ring-middleware "1.0.1"]
                          [puppetlabs/dujour-version-check "0.2.1"]


### PR DESCRIPTION
update tk-filesystem-watcher to ignore lock directories that disappear when registering