### PR TITLE
(SERVER-2734) Update tk-jetty9 to 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.3.2]
+
+- update tk-jetty9 to fix a type inference ambiguity in Java 11
+
 ## [4.3.1]
 
 - update tk-filesystem-watcher to ignore lock directories that disappear when registering.

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.10.1")
 (def ks-version "3.0.0")
 (def tk-version "3.0.0")
-(def tk-jetty-version "4.0.2")
+(def tk-jetty-version "4.0.3")
 (def tk-metrics-version "1.2.0")
 (def logback-version "1.2.3")
 (def rbac-client-version "0.9.4")


### PR DESCRIPTION
This update contains a fix for type ambiguity in Java 11.
