### PR TITLE
(maint) bump tk-metrics to 1.2.1, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [1.7.32]
+- update tk-metrics to 1.2.1
+
 ## [1.7.31]
 - update tk-filesystem-watcher to ignore lock directories that disappear when registering.
 

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "2.5.2")
 (def tk-version "2.0.1")
 (def tk-jetty-version "2.4.1")
-(def tk-metrics-version "1.2.0")
+(def tk-metrics-version "1.2.1")
 (def logback-version "1.1.9")
 (def rbac-client-version "0.9.4")
 (def dropwizard-metrics-version "3.2.2")


### PR DESCRIPTION
Update tk-metrics to 1.2.1 and update the change log.