### PR TITLE
(maint) Bump tk-metrics to clojars' version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.7.34]
+
+- update tk-metrics to 1.2.2, which is available on clojars. tk-metrics 1.2.1 was an internal-only release
+
 ## [1.7.32]
 
 - update tk-metrics to 1.2.1

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "2.5.2")
 (def tk-version "2.0.1")
 (def tk-jetty-version "2.4.1")
-(def tk-metrics-version "1.2.1")
+(def tk-metrics-version "1.2.2")
 (def logback-version "1.1.9")
 (def rbac-client-version "0.9.4")
 (def dropwizard-metrics-version "3.2.2")


### PR DESCRIPTION
1.2.1 was only released to artifactory, 1.2.2 is available on clojars.