### PR TITLE
(SERVER-2565) Update kitchensink to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.4.2]
+
+- update kitchensink to 3.1.0, which contains a function for doing atomic file writes
+
 ## [4.4.1]
 
 - update tk-metrics to 1.2.2, which is available on clojars. tk-metrics 1.2.1 was an internal-only release

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.10.1")
-(def ks-version "3.0.0")
+(def ks-version "3.1.0")
 (def tk-version "3.1.0")
 (def tk-jetty-version "4.0.3")
 (def tk-metrics-version "1.2.2")


### PR DESCRIPTION
This update contains a new function for doing atomic file writes.
