### PR TITLE
(SERVER-2793) Downgrade JRuby to 9.2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.4.4]
+
+- update jruby-utils to 3.1.2, which downgrades JRuby to 9.2.8.0 to avoid a potential bug in 9.2.11.1
+
 ## [4.4.3]
 
 - update clj-ldap to 0.3.0, which allows passing an array of trust-managers in the connection options

--- a/project.clj
+++ b/project.clj
@@ -126,7 +126,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.0.2"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "3.1.1"]
+                         [puppetlabs/jruby-utils "3.1.2"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
We found a potential bug in JRuby 9.2.11.1, so this commit updates
jruby-utils to a version with JRuby rolled back to 9.2.8.0.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
