### PR TITLE
(SERVER-2793) Bump JRuby back to 9.2.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.4.5]
+
+- update jruby-utils to 3.1.3, which reverts the JRuby downgrade and brings back 9.2.11.1
+
 ## [4.4.4]
 
 - update jruby-utils to 3.1.2, which downgrades JRuby to 9.2.8.0 to avoid a potential bug in 9.2.11.1

--- a/project.clj
+++ b/project.clj
@@ -126,7 +126,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.0.2"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "3.1.2"]
+                         [puppetlabs/jruby-utils "3.1.3"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
We're going to give this another try now that the last release went out.