### PR TITLE
(TK-486) Update tk-metrics to 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.7.35]
+
+- update tk-metrics to 1.2.3, which deprecates the v1 metrics endpoint.
+
 ## [1.7.34]
 
 - update tk-metrics to 1.2.2, which is available on clojars. tk-metrics 1.2.1 was an internal-only release

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "2.5.2")
 (def tk-version "2.0.1")
 (def tk-jetty-version "2.4.1")
-(def tk-metrics-version "1.2.2")
+(def tk-metrics-version "1.2.3")
 (def logback-version "1.1.9")
 (def rbac-client-version "0.9.4")
 (def dropwizard-metrics-version "3.2.2")


### PR DESCRIPTION
This update deprecates the v1 metrics endpoint.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
