### PR TITLE
(maint) Update i18n to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.5.1]
+
+- update i18n to 0.9.0, which removes the plugin hook.
+
 ## [4.5.0]
 
 - update trapperkeeper-webserver-jetty9 to 4.1.0, which bumps jetty to 9.4.28 to

--- a/project.clj
+++ b/project.clj
@@ -120,7 +120,7 @@
                          [puppetlabs/dujour-version-check "0.2.3"]
                          [puppetlabs/comidi "0.3.2"]
                          [puppetlabs/trapperkeeper-comidi-metrics "0.1.1"]
-                         [puppetlabs/i18n "0.8.0"]
+                         [puppetlabs/i18n "0.9.0"]
                          [puppetlabs/cljs-dashboard-widgets "0.1.0"]
                          [puppetlabs/rbac-client ~rbac-client-version]
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]


### PR DESCRIPTION
This commit updates i18n to 0.9.0. This is the latest version and what puppetdb
is already using.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
