### PR TITLE
(SERVER-2783) Update jruby-utils

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -126,7 +126,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.0.2"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "3.1.3"]
+                         [puppetlabs/jruby-utils "3.1.4"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
This version of jruby-utils turns off invokedynamic for yield, which may
be causing stack overflows.


Please add all notable changes to the "Unreleased" section of the CHANGELOG.