### PR TITLE
(PE-28654) bump ring middleware version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [4.5.5]
+
+- update ring-middleware to 1.1.0, which adds
+  new wrappers for use in console-ui.
+
 ## [4.5.4]
 
 - update trapperkeeper-metrics to 1.3.1, which adds tk-authorization

--- a/project.clj
+++ b/project.clj
@@ -116,7 +116,7 @@
                          [puppetlabs/trapperkeeper-status "1.1.0"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.2.2"]
                          [puppetlabs/structured-logging "0.2.0"]
-                         [puppetlabs/ring-middleware "1.0.1"]
+                         [puppetlabs/ring-middleware "1.1.0"]
                          [puppetlabs/dujour-version-check "0.2.3"]
                          [puppetlabs/comidi "0.3.2"]
                          [puppetlabs/trapperkeeper-comidi-metrics "0.1.1"]


### PR DESCRIPTION
This commit bumps ring middleware to 1.1.0, to pull in a couple new wrappers for use in console-ui.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
