### PR TITLE
(SERVER-2801) Bump bouncycastle/bctls-fips to 1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- update bctls-fips to 1.0.10
+
 ## [4.5.5]
 
 - update ring-middleware to 1.1.0, which adds

--- a/project.clj
+++ b/project.clj
@@ -135,7 +135,7 @@
                          ;; https://github.com/puppetlabs/bouncy-castle-vanagon
                          [org.bouncycastle/bcpkix-fips "1.0.3"]
                          [org.bouncycastle/bc-fips "1.0.2"]
-                         [org.bouncycastle/bctls-fips "1.0.9"]
+                         [org.bouncycastle/bctls-fips "1.0.10"]
                          [org.bouncycastle/bcpkix-jdk15on "1.60"]]
 
   :dependencies [[org.clojure/clojure]]


### PR DESCRIPTION
This commit bumps bctls-fips to 1.0.10 to ensure we're on the latest version
in the LTS.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
