### PR TITLE
(PE-29720) update clj-rbac-client and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [4.6.1]
+- update clj-rbac-client to 1.0.0 to add support for the activity service v2 submission endpoint
+
 ## [4.6.0]
 
 - update bctls-fips to 1.0.10

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "4.1.0")
 (def tk-metrics-version "1.3.1")
 (def logback-version "1.2.3")
-(def rbac-client-version "0.9.4")
+(def rbac-client-version "1.0.0")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "4.6.1-SNAPSHOT"


### PR DESCRIPTION
This updates clj-rbac-client to 1.0.0, which adds support for the upcoming "v2" submission endpoint.  If the service does not support the v2 endpoint, the client will gracefully roll back to use the v1 endpoint.

Also the changelog was updated with the intent of creating a new release.