### PR TITLE
(SERVER-2853) Update jruby-utils to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## [Unreleased]
+
+## [4.6.2]
+
 - update prismatic-schema to 1.1.12, which has a few bug fixes
+- update jruby-utils to 3.2.0, which updates JRuby to 9.2.13.0
 
 ## [4.6.1]
+
 - update clj-rbac-client to 1.0.0 to add support for the activity service v2 submission endpoint
 
 ## [4.6.0]

--- a/project.clj
+++ b/project.clj
@@ -126,7 +126,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.0.2"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "3.1.4"]
+                         [puppetlabs/jruby-utils "3.2.0"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
This update contains JRuby 9.2.13.0, which has some security fixes.
