### PR TITLE
(SERVER-2859) Update jvm-ssl-utils to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.7.37]
+
+- update jvm-ssl-utils to 1.1.0, which adds a method for revoking multiple certs
+
 ## [1.7.36]
 
 - update postgres jdbc driver to 4.2.14, which has security fixes

--- a/project.clj
+++ b/project.clj
@@ -96,7 +96,7 @@
                          [puppetlabs/http-client "1.0.0"]
                          [puppetlabs/jdbc-util "1.2.5"]
                          [puppetlabs/typesafe-config "0.1.5"]
-                         [puppetlabs/ssl-utils "1.0.2"]
+                         [puppetlabs/ssl-utils "1.1.0"]
                          [puppetlabs/clj-ldap "0.2.1"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]


### PR DESCRIPTION
This update adds a new method to revoke multiple certs at once.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
