### PR TITLE
(SERVER-2859) Update jvm-ssl-utils to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.6.3]
+
+- update jvm-ssl-utils to 3.1.0, which contains a function to revoke multiple certs at once
+
 ## [4.6.2]
 
 - update prismatic-schema to 1.1.12, which has a few bug fixes

--- a/project.clj
+++ b/project.clj
@@ -101,7 +101,7 @@
                          [puppetlabs/http-client "1.1.3"]
                          [puppetlabs/jdbc-util "1.2.5"]
                          [puppetlabs/typesafe-config "0.1.5"]
-                         [puppetlabs/ssl-utils "3.0.5"]
+                         [puppetlabs/ssl-utils "3.1.0"]
                          [puppetlabs/clj-ldap "0.3.0"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]


### PR DESCRIPTION
This update adds a function to revoke multiple certificates at once.
