### PR TITLE
(SERVER-2863) Update clj-kitchensink to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.7.38]
+
+- update clj-kitchensink to 2.6.0, which adds an function to atomically write files
+
 ## [1.7.37]
 
 - update jvm-ssl-utils to 1.1.0, which adds a method for revoking multiple certs

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.8.0")
-(def ks-version "2.5.2")
+(def ks-version "2.6.0")
 (def tk-version "2.0.1")
 (def tk-jetty-version "2.4.1")
 (def tk-metrics-version "1.2.3")


### PR DESCRIPTION
This commit updates clj-kitchensink to 2.6.0, which adds a function to
atomically write files.
