### PR TITLE
(PE-29997) update clj-rbac-client to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased]
+
+## [4.6.4]
+
 - update clj-rbac-client to 1.1.0 to remove harmful language and add a method to the rbac consumer protocol
 - update tk-status to 1.1.1 which includes additional java memory info
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update clj-rbac-client to 1.1.0 to remove harmful language and add a method to the rbac consumer protocol
 - update tk-status to 1.1.1 which includes additional java memory info
 
 ## [4.6.3]

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "4.1.0")
 (def tk-metrics-version "1.3.1")
 (def logback-version "1.2.3")
-(def rbac-client-version "1.0.0")
+(def rbac-client-version "1.1.0")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "4.6.4-SNAPSHOT"


### PR DESCRIPTION
This updates clj-rbac-client to 1.1.0, which contains deprecations
for functions that contain harmful language, and adds a new function
to replace a deprecated method.

Also prepare for the 4.6.4 release.