### PR TITLE
(PE-30059) update clj-rbac-client to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.6.5]
+
+- update clj-rbac-client to 1.1.1 to fix a bug introduced in 1.1.0
+
 ## [4.6.4]
 
 - update clj-rbac-client to 1.1.0 to remove harmful language and add a method to the rbac consumer protocol

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "4.1.0")
 (def tk-metrics-version "1.3.1")
 (def logback-version "1.2.3")
-(def rbac-client-version "1.1.0")
+(def rbac-client-version "1.1.1")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "4.6.5-SNAPSHOT"


### PR DESCRIPTION
This updates the clj-rbac-client version to 1.1.1, which includes a fix for a bug introduced in the 1.1.0 version.
