### PR TITLE
(SERVER-2780) Update clj-http-client to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.6.6]
+
+- update clj-http-client to 1.2.0, which allows retrieving the message from a response status
+
 ## [4.6.5]
 
 - update clj-rbac-client to 1.1.1 to fix a bug introduced in 1.1.0

--- a/project.clj
+++ b/project.clj
@@ -98,7 +98,7 @@
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.12"]
 
-                         [puppetlabs/http-client "1.1.3"]
+                         [puppetlabs/http-client "1.2.0"]
                          [puppetlabs/jdbc-util "1.2.5"]
                          [puppetlabs/typesafe-config "0.1.5"]
                          [puppetlabs/ssl-utils "3.1.0"]


### PR DESCRIPTION
This update has a function for retrieving the message from a response
status.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
