### PR TITLE
(maint) update clj-kitchensink to 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- update clj-kitchensink to 3.1.1, which changes the open-port-num function to select a port
+  in the 16384 - 32767 range. This should decrease port binding collisions in some cases.
+
 ## [4.6.6]
 
 - update clj-http-client to 1.2.0, which allows retrieving the message from a response status

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.10.1")
-(def ks-version "3.1.0")
+(def ks-version "3.1.1")
 (def tk-version "3.1.0")
 (def tk-jetty-version "4.1.0")
 (def tk-metrics-version "1.3.1")


### PR DESCRIPTION
This commit updates clj-kitchensink 3.1.1 which changes the open-port-num
function to select a port in the 16384 - 32767 range. This should decrease port
binding collisions in some cases.


