### PR TITLE
(PE-30230) update ring-middleware version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [4.6.8]
+
+- update ring-middleware to 1.3.0, which updates `wrap-add-cache-headers` to use
+  the "no-store" cache-control directive instead of "private, max-age=0, no-cache"
+
 ## [4.6.7]
 
 - update clj-kitchensink to 3.1.1, which changes the open-port-num function to select a port

--- a/project.clj
+++ b/project.clj
@@ -116,7 +116,7 @@
                          [puppetlabs/trapperkeeper-status "1.1.1"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.2.2"]
                          [puppetlabs/structured-logging "0.2.0"]
-                         [puppetlabs/ring-middleware "1.2.0"]
+                         [puppetlabs/ring-middleware "1.3.0"]
                          [puppetlabs/dujour-version-check "0.2.3"]
                          [puppetlabs/comidi "0.3.2"]
                          [puppetlabs/trapperkeeper-comidi-metrics "0.1.1"]


### PR DESCRIPTION
This sets the ring-middleware version to 1.3.0, which updates `wrap-add-cache-headers` to use
the "no-store" cache-control directive instead of "private, max-age=0, no-cache"
