### PR TITLE
(maint) update tk-scheduler to 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [4.6.9]
+
+- update tk-scheduler to 1.1.3, which updates the quartz library to the latest z, and adds checks to
+  prevent null functions from being passed to the scheduler
+
 ## [4.6.8]
 
 - update ring-middleware to 1.3.0, which updates `wrap-add-cache-headers` to use

--- a/project.clj
+++ b/project.clj
@@ -111,7 +111,7 @@
                          [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version :classifier "test"]
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version]
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version :classifier "test"]
-                         [puppetlabs/trapperkeeper-scheduler "1.1.2"]
+                         [puppetlabs/trapperkeeper-scheduler "1.1.3"]
                          [puppetlabs/trapperkeeper-authorization "1.0.0"]
                          [puppetlabs/trapperkeeper-status "1.1.1"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.2.2"]


### PR DESCRIPTION
This updates trapperkeeper-scheduler to 1.1.3 to update the quartz library to a more recent z version and to add protection from scheduling null values for the scheduled functions.