### PR TITLE
(maint) Upgrade JRuby to 9.2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.6.10]
+
+ - update jruby-utils to 3.2.1 bringing in JRuby 9.2.14.0, a minor update that resolves a webrick CVE.
+
 ## [4.6.9]
 
 - update tk-scheduler to 1.1.3, which updates the quartz library to the latest z, and adds checks to

--- a/project.clj
+++ b/project.clj
@@ -126,7 +126,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.0.2"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "3.2.0"]
+                         [puppetlabs/jruby-utils "3.2.1"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
