### PR TITLE
(maint) Update typesafe config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [4.6.11]
+
+- update clj-typesafe-config to 0.2.0 bringing in typesafe/config 1.4.1, an ABI-compatible feature update from the previous release of 1.2.0.
+- update ring dependencies to current latest releases
+
 ## [4.6.10]
 
  - update jruby-utils to 3.2.1 bringing in JRuby 9.2.14.0, a minor update that resolves a webrick CVE.

--- a/project.clj
+++ b/project.clj
@@ -100,7 +100,7 @@
 
                          [puppetlabs/http-client "1.2.0"]
                          [puppetlabs/jdbc-util "1.2.5"]
-                         [puppetlabs/typesafe-config "0.1.5"]
+                         [puppetlabs/typesafe-config "0.2.0"]
                          [puppetlabs/ssl-utils "3.1.0"]
                          [puppetlabs/clj-ldap "0.3.0"]
                          [puppetlabs/kitchensink ~ks-version]


### PR DESCRIPTION
Upgrades to the current latest release of https://github.com/lightbend/config with an upgrade to our wrapper library. Primarily improves referencing environment variable lists.