### PR TITLE
(PE-30976) Security updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- update tk-jetty9 to 4.1.1, which contains jetty 9.4.36, a maintenance update with some security fixes
+
 ## [4.6.11]
 
 - update clj-typesafe-config to 0.2.0 bringing in typesafe/config 1.4.1, an ABI-compatible feature update from the previous release of 1.2.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [Unreleased]
 
+## [4.6.12]
+
 - update tk-jetty9 to 4.1.1, which contains jetty 9.4.36, a maintenance update with some security fixes
+- update bouncy-castle to 1.68, which contains some security fixes
 
 ## [4.6.11]
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.10.1")
 (def ks-version "3.1.1")
 (def tk-version "3.1.0")
-(def tk-jetty-version "4.1.0")
+(def tk-jetty-version "4.1.1")
 (def tk-metrics-version "1.3.1")
 (def logback-version "1.2.3")
 (def rbac-client-version "1.1.1")

--- a/project.clj
+++ b/project.clj
@@ -136,7 +136,7 @@
                          [org.bouncycastle/bcpkix-fips "1.0.3"]
                          [org.bouncycastle/bc-fips "1.0.2"]
                          [org.bouncycastle/bctls-fips "1.0.10"]
-                         [org.bouncycastle/bcpkix-jdk15on "1.66"]]
+                         [org.bouncycastle/bcpkix-jdk15on "1.68"]]
 
   :dependencies [[org.clojure/clojure]]
 


### PR DESCRIPTION
This updates jetty and bouncy castle.

No issues with either in any puppetserver project.
