### PR TITLE
(PE-31011) Update jackson to 2.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [4.6.13]
+
+- update jackson-core, jackson-databind and jackson-module-afterburner to 2.12.1 for security fixes
 ## [4.6.12]
 
 - update tk-jetty9 to 4.1.1, which contains jetty 9.4.36, a maintenance update with some security fixes

--- a/project.clj
+++ b/project.clj
@@ -39,9 +39,9 @@
                          [ch.qos.logback/logback-access ~logback-version]
                          [net.logstash.logback/logstash-logback-encoder "5.0"]
                          [org.codehaus.janino/janino "3.0.8"]
-                         [com.fasterxml.jackson.core/jackson-core "2.10.0"]
-                         [com.fasterxml.jackson.core/jackson-databind "2.10.0"]
-                         [com.fasterxml.jackson.module/jackson-module-afterburner "2.10.0"]
+                         [com.fasterxml.jackson.core/jackson-core "2.12.1"]
+                         [com.fasterxml.jackson.core/jackson-databind "2.12.1"]
+                         [com.fasterxml.jackson.module/jackson-module-afterburner "2.12.1"]
                          [org.yaml/snakeyaml "1.23"]
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]


### PR DESCRIPTION
This commit updates our jackson dependencies to the latest version to
fix a known security vulnerability.