### PR TITLE
(SERVER-2948) Bump ring-servlet back to known good version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.6.15]
+
+- pin ring-servlet back to 1.5.1 until we figure out what is causing binary file test failures
+
 ## [4.6.14]
 
 - update tk-jetty9 to 4.1.3, which updates a dependency pin to avoid conflicts with other libs

--- a/project.clj
+++ b/project.clj
@@ -74,7 +74,7 @@
                          [cheshire "5.8.0"]
                          [compojure "1.5.0"]
                          [quoin "0.1.2"]
-                         [ring/ring-servlet "1.8.2"]
+                         [ring/ring-servlet "1.5.1"]
                          [ring/ring-core "1.8.2"]
                          [ring/ring-codec "1.1.2"]
                          [ring/ring-json "0.5.0"]


### PR DESCRIPTION
This commit bumps our ring-servlet dependency back to 1.5.1. This is the latest
release that doesn't cause failures in our beaker tests. We will ultimately need
to bump this back, but for now we need to get CI green.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
