### PR TITLE
(PE-30976) Update commons-beanutils to 1.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- update commons-beanutils to 1.9.4, which contains a security fix.
+
 ## [4.6.15]
 
 - pin ring-servlet back to 1.5.1 until we figure out what is causing binary file test failures

--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
                          [org.apache.httpcomponents/httpclient  "4.5.2"]
                          [org.apache.httpcomponents/httpcore  "4.4.5"]
                          [org.apache.httpcomponents/httpasyncclient "4.1.4"]
-                         [commons-beanutils "1.9.2"]
+                         [commons-beanutils "1.9.4"]
                          [commons-codec "1.10"]
                          [commons-collections "3.2.2"]
                          [commons-lang "2.6"]


### PR DESCRIPTION
This fixes things for file-sync, overriding the version that comes in with `commons-validator`.

I also examined the deps in pe-puppetdb-extensions, and it looks like this also overrides what shiro brings in.