### PR TITLE
(PE-31016) Bump commons-compress and clj-commons/fs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [4.6.17]
+
+- update commons-compress to 1.20, which contains a security fix.
+- update clj-commons/fs to 1.6.307, which contains a matching commons-compress version
+
 ## [4.6.16]
 
 - update commons-beanutils to 1.9.4, which contains a security fix.

--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,7 @@
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]
                          [org.apache.commons/commons-exec "1.3"]
-                         [org.apache.commons/commons-compress "1.17"]
+                         [org.apache.commons/commons-compress "1.20"]
                          [org.apache.commons/commons-lang3 "3.4"]
                          [org.apache.httpcomponents/httpclient  "4.5.2"]
                          [org.apache.httpcomponents/httpcore  "4.4.5"]
@@ -68,7 +68,7 @@
                          [clj-commons/clj-yaml "0.7.2"]
                          [clj-stacktrace "0.2.8"]
                          [com.zaxxer/HikariCP "2.7.4"]
-                         [clj-commons/fs "1.5.1"]
+                         [clj-commons/fs "1.6.307"]
                          [instaparse "1.4.1"]
                          [slingshot "0.12.2"]
                          [cheshire "5.8.0"]


### PR DESCRIPTION
The commons-compress bump fixes a known CVE. We also bump clj-commons/fs
since that library also depends on commons-compress. Note that our
commons-compress version matches what's in clj-commons/fs.

Signed-off-by: Enis Inan <enis.inan@puppet.com>

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
