### PR TITLE
(PDB-5000) Update nippy to 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - update commons-beanutils to 1.9.4, which contains a security fix.
+- update nippy to 3.1.1, security fixes. May require adjustments to the usage of `thaw`
 
 ## [4.6.15]
 

--- a/project.clj
+++ b/project.clj
@@ -59,8 +59,8 @@
                          [commons-io "2.4"]
                          [joda-time "2.8.2"]
 
-                         [com.taoensso/nippy "2.14.0"]
-                         [com.taoensso/encore "2.115.0"]
+                         [com.taoensso/nippy "3.1.1"]
+                         [com.taoensso/encore "3.9.2"]
 
                          [nrepl/nrepl "0.6.0"]
                          [bidi "2.1.3"]


### PR DESCRIPTION
To fix the CVE this has a potentially breaking change to the freeze and
thaw methods. If a class you need to thaw is not on the allowlist you
will need to bind a new set of allowed java classes to thaw. It would
look something like the example below.
```
(binding [nippy/*thaw-serializable-allowlist* #{"org.joda.time.DateTime"}]
  (nippy/thaw (Files/readAllBytes path)))
```

Upgrading to 2.15.3 would have also negated the CVE, but 2.15.0 had a
breaking change even though it was a y release. And by going to the 3.y
versions we can use the allowlist instead of the initial whitelist that
they added in 2.15.0 and later renamed.
