### PR TITLE
Revert "(SERVER-2948) Bump ring-servlet back to known good version"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## [Unreleased]
 
+## [4.6.16]
+
 - update commons-beanutils to 1.9.4, which contains a security fix.
 - update nippy to 3.1.1, security fixes. May require adjustments to the usage of `thaw`
+- update ring-servlet back to 1.8.2 now that our failures have been resolved
 
 ## [4.6.15]
 

--- a/project.clj
+++ b/project.clj
@@ -74,7 +74,7 @@
                          [cheshire "5.8.0"]
                          [compojure "1.5.0"]
                          [quoin "0.1.2"]
-                         [ring/ring-servlet "1.5.1"]
+                         [ring/ring-servlet "1.8.2"]
                          [ring/ring-core "1.8.2"]
                          [ring/ring-codec "1.1.2"]
                          [ring/ring-json "0.5.0"]


### PR DESCRIPTION
This reverts commit 49a95882e6b97cd456c14d0a11496fa3c7df3436.
We have made the necessary updates to take up this new version of ring-servlet.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
