### PR TITLE
(PE-31121) update clj-kitchensink to 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- update clj-kitchensink to bring in the addition of the base-type function for parsing Content-Type headers
+
 ## [4.6.17]
 
 - update commons-compress to 1.20, which contains a security fix.

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.10.1")
-(def ks-version "3.1.1")
+(def ks-version "3.1.3")
 (def tk-version "3.1.0")
 (def tk-jetty-version "4.1.3")
 (def tk-metrics-version "1.4.0")


### PR DESCRIPTION
To bring in the addition of the base-type function for
parsing Content-Type headers.


