### PR TITLE
(maint) prep for 4.6.18 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [4.6.18]
+
 - update clj-kitchensink to bring in the addition of the base-type function for parsing Content-Type headers
 
 ## [4.6.17]


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
