### PR TITLE
(PE-31797) Update tk-jetty9 to 4.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.6.19]
+
+- update tk-jetty9 to 4.1.5, which contains several security fixes
+
 ## [4.6.18]
 
 - update clj-kitchensink to bring in the addition of the base-type function for parsing Content-Type headers

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.10.1")
 (def ks-version "3.1.3")
 (def tk-version "3.1.0")
-(def tk-jetty-version "4.1.3")
+(def tk-jetty-version "4.1.5")
 (def tk-metrics-version "1.4.0")
 (def logback-version "1.2.3")
 (def rbac-client-version "1.1.1")


### PR DESCRIPTION
This contains fixes for several CVEs.
