### PR TITLE
(SERVER-3007) Update jruby-utils to 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.6.21]
+
+- update jruby-utils to 3.2.2, which brings in JRuby 9.2.17.0
+
 ## [4.6.20]
 
 - update tk-jetty9 to 4.1.6, which contains a fix for a connection reset bug

--- a/project.clj
+++ b/project.clj
@@ -126,7 +126,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.0.2"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "3.2.1"]
+                         [puppetlabs/jruby-utils "3.2.2"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
This brings in JRuby 9.2.17.0, which is a maintenance update.