### PR TITLE
(SERVER-2550) Update jvm-ssl-utils to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.6.23]
+
+- update jvm-ssl-utils to 3.2.0, which containts more advanced CRL utilities
+
 ## [4.6.22]
 
 - update apache httpclient to 4.5.13 (CVE-2020-13956)

--- a/project.clj
+++ b/project.clj
@@ -101,7 +101,7 @@
                          [puppetlabs/http-client "1.2.0"]
                          [puppetlabs/jdbc-util "1.2.5"]
                          [puppetlabs/typesafe-config "0.2.0"]
-                         [puppetlabs/ssl-utils "3.1.0"]
+                         [puppetlabs/ssl-utils "3.2.0"]
                          [puppetlabs/clj-ldap "0.3.0"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]


### PR DESCRIPTION
This update contains more advanced functions for generating and
validating CRLs.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
