### PR TITLE
(maint) Update jvm-ssl-utils to 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## [Unreleased]
 
+## [4.6.24]
+
+- update jvm-ssl-utils to 3.2.2, which contains a fix to stay compatible with both FOSS and FIPS Bouncy Castle APIs and some new extension utilities.
+
 ## [4.6.23]
 
-- update jvm-ssl-utils to 3.2.0, which containts more advanced CRL utilities
+- update jvm-ssl-utils to 3.2.0, which contains more advanced CRL utilities
 
 ## [4.6.22]
 

--- a/project.clj
+++ b/project.clj
@@ -101,7 +101,7 @@
                          [puppetlabs/http-client "1.2.0"]
                          [puppetlabs/jdbc-util "1.2.5"]
                          [puppetlabs/typesafe-config "0.2.0"]
-                         [puppetlabs/ssl-utils "3.2.0"]
+                         [puppetlabs/ssl-utils "3.2.2"]
                          [puppetlabs/clj-ldap "0.3.0"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]


### PR DESCRIPTION
This update fixes a compatibility issue between FOSS and FIPS Bouncy
Castle, as well as adds some new extension utilities.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
