### PR TITLE
(maint) Update BC FIPS to latest

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -133,9 +133,9 @@
                          ;; for BC (ie, clj-parent manages these versions for
                          ;; dev and FOSS, PE is managed via packages):
                          ;; https://github.com/puppetlabs/bouncy-castle-vanagon
-                         [org.bouncycastle/bcpkix-fips "1.0.3"]
-                         [org.bouncycastle/bc-fips "1.0.2"]
-                         [org.bouncycastle/bctls-fips "1.0.10"]
+                         [org.bouncycastle/bcpkix-fips "1.0.5"]
+                         [org.bouncycastle/bc-fips "1.0.2.1"]
+                         [org.bouncycastle/bctls-fips "1.0.11.4"]
                          [org.bouncycastle/bcpkix-jdk15on "1.68"]]
 
   :dependencies [[org.clojure/clojure]]


### PR DESCRIPTION
We recently updated BC's FOSS releases (in January), at the time of
upgrade BC's updates to their FIPS libraries had not been revalidated.
They now are (passed in April) and this patch updates our FIPS libraries
to the latest release. They should be covered by certificate #3514, see:
https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3514

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
