### PR TITLE
(maint) Update clojurescript to 1.10.866

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- update clojurescript to 1.10.866, which resolves CVEs in several transitive dependencies
+
 ## [4.6.24]
 
 - update jvm-ssl-utils to 3.2.2, which contains a fix to stay compatible with both FOSS and FIPS Bouncy Castle APIs and some new extension utilities.

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
   :packaging "pom"
 
   :managed-dependencies [[org.clojure/clojure ~clj-version]
-                         [org.clojure/clojurescript "1.7.122"]
+                         [org.clojure/clojurescript "1.10.866"]
                          [org.clojure/tools.logging "0.4.0"]
                          [org.clojure/tools.cli "0.3.6"]
                          [org.clojure/tools.nrepl "0.2.13"]


### PR DESCRIPTION
This commit updates clojurescript to the latest release in order to resolve CVEs
in transitive dependencies.
