### PR TITLE
(SERVER-3016) Update jvm-ssl-utils to 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [4.6.26]
 
 - update jvm-ssl-utils to 3.3.0, which now supports OpenSSL-formatted EC private keys
+- update tk-jetty9 to 4.1.7, which resolves CVE-2021-28169
 
 ## [4.6.25]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - update jvm-ssl-utils to 3.3.0, which now supports OpenSSL-formatted EC private keys
 - update tk-jetty9 to 4.1.7, which resolves CVE-2021-28169
+- update BC FIPS libraries to latest versions
 
 ## [4.6.25]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.6.26]
+
+- update jvm-ssl-utils to 3.3.0, which now supports OpenSSL-formatted EC private keys
+
 ## [4.6.25]
 
 - update clojurescript to 1.10.866, which resolves CVEs in several transitive dependencies

--- a/project.clj
+++ b/project.clj
@@ -101,7 +101,7 @@
                          [puppetlabs/http-client "1.2.0"]
                          [puppetlabs/jdbc-util "1.2.5"]
                          [puppetlabs/typesafe-config "0.2.0"]
-                         [puppetlabs/ssl-utils "3.2.2"]
+                         [puppetlabs/ssl-utils "3.3.0"]
                          [puppetlabs/clj-ldap "0.3.0"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.10.1")
 (def ks-version "3.1.3")
 (def tk-version "3.1.0")
-(def tk-jetty-version "4.1.6")
+(def tk-jetty-version "4.1.7")
 (def tk-metrics-version "1.4.0")
 (def logback-version "1.2.3")
 (def rbac-client-version "1.1.1")


### PR DESCRIPTION
This version contains support for EC private keys with an EC parameter
block in the PEM file.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
