### PR TITLE
(SEC-739) Update commons-compress to 1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.6.27]
+
+- update commons-compress to 1.21 to fix several CVEs
+
 ## [4.6.26]
 
 - update jvm-ssl-utils to 3.3.0, which now supports OpenSSL-formatted EC private keys

--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,7 @@
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]
                          [org.apache.commons/commons-exec "1.3"]
-                         [org.apache.commons/commons-compress "1.20"]
+                         [org.apache.commons/commons-compress "1.21"]
                          [org.apache.commons/commons-lang3 "3.4"]
                          [org.apache.httpcomponents/httpclient  "4.5.13"]
                          [org.apache.httpcomponents/httpcore  "4.4.13"]


### PR DESCRIPTION
This update fixes the following CVEs: CVE-2021-36090, CVE-2021-35515,
CVE-2021-35516, CVE-2021-35517.
