### PR TITLE
(SEC-745) update Jetty to 9.4.43 (CVE-2021-34429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.6.28]
+
+- update trapperkeeper-webserver-jetty9 to 4.1.8 to bring in Jetty v9.4.43 to resolve CVE-2021-34429
+
 ## [4.6.27]
 
 - update commons-compress to 1.21 to fix several CVEs

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.10.1")
 (def ks-version "3.1.3")
 (def tk-version "3.1.0")
-(def tk-jetty-version "4.1.7")
+(def tk-jetty-version "4.1.8")
 (def tk-metrics-version "1.4.0")
 (def logback-version "1.2.3")
 (def rbac-client-version "1.1.1")


### PR DESCRIPTION
This commit updates trapperkeeper-webserver-jetty9 to 4.1.8 to bring
in Jetty v9.4.43 to resolve CVE-2021-34429.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
