### PR TITLE
(PDB-5206) update i18n to 0.9.2 which has the fixes made in PDB-5190

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [4.6.29]
+
+- update i18n to 0.9.2 which fixes some reflection issues.
+
 ## [4.6.28]
 
 - update trapperkeeper-webserver-jetty9 to 4.1.8 to bring in Jetty v9.4.43 to resolve CVE-2021-34429

--- a/project.clj
+++ b/project.clj
@@ -120,7 +120,7 @@
                          [puppetlabs/dujour-version-check "0.2.3"]
                          [puppetlabs/comidi "0.3.2"]
                          [puppetlabs/trapperkeeper-comidi-metrics "0.1.1"]
-                         [puppetlabs/i18n "0.8.0"]
+                         [puppetlabs/i18n "0.9.2"]
                          [puppetlabs/cljs-dashboard-widgets "0.1.0"]
                          [puppetlabs/rbac-client ~rbac-client-version]
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]


### PR DESCRIPTION
i18n 0.9.2 adds some improvements to PuppetDB's query performance. This improvements are detailed in https://github.com/puppetlabs/clj-i18n/pull/49.

Also tested if this introduces problems with restarting PuppetDB via SIGHUP and it works fine with JAVA 8. 
This is not the case with JAVA 11, but TK services restart also fails with the  current version of i18n.