### PR TITLE
(maint) Bump tk-metrics to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- update tk-metrics to 1.4.1, which includes Jolokia 1.7.0, a routine maintenance bump that cleans up some reflective accesses that trigger warnings in Java 9 and newer.
+
 ## [4.6.29]
 
 - update i18n to 0.9.2 which fixes some reflection issues.

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "3.1.3")
 (def tk-version "3.1.0")
 (def tk-jetty-version "4.1.8")
-(def tk-metrics-version "1.4.0")
+(def tk-metrics-version "1.4.1")
 (def logback-version "1.2.3")
 (def rbac-client-version "1.1.1")
 (def dropwizard-metrics-version "3.2.2")


### PR DESCRIPTION
This commit updates trapperkeeper-metrics to 1.4.1, which includes Jolokia
1.7.0, a routine maintenance bump that cleans up some reflective accesses that
trigger warnings in Java 9 and newer.
