### PR TITLE
Revert "(maint) Bump tk-metrics to 1.4.1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [4.7.1]
+- revert update to tk-metrics, the updated jolokia caused issues in FIPS environments
+
 ## [4.7.0]
 - update jdbc to 0.7.11, update jdbc-util to 1.3.0, due to a change in version for migratus
 

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "3.1.3")
 (def tk-version "3.1.0")
 (def tk-jetty-version "4.1.8")
-(def tk-metrics-version "1.4.1")
+(def tk-metrics-version "1.4.0")
 (def logback-version "1.2.3")
 (def rbac-client-version "1.1.1")
 (def dropwizard-metrics-version "3.2.2")


### PR DESCRIPTION
This reverts commit cf1daa93bdd406e22c80cf1c0e1669a083adba57.

We discovered that this update caused issues in FIPS environments. While
we look into that, we are reverting the update.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
