### PR TITLE
(maint) Update tk-metrics to 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## [Unreleased]
 
+## [4.7.2]
+- update tk-metrics to 1.4.3, which fixes an issue with its Bouncy Castle dependency that caused issues in FIPS mode. This also reintroduces the jolokia 1.7.0 bump (which was not implicated in the FIPS bug).
+
 ## [4.7.1]
-- revert update to tk-metrics, the updated jolokia caused issues in FIPS environments
+- revert update to tk-metrics, the previous update caused issues in FIPS environments
 
 ## [4.7.0]
 - update jdbc to 0.7.11, update jdbc-util to 1.3.0, due to a change in version for migratus

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "3.1.3")
 (def tk-version "3.1.0")
 (def tk-jetty-version "4.1.8")
-(def tk-metrics-version "1.4.0")
+(def tk-metrics-version "1.4.3")
 (def logback-version "1.2.3")
 (def rbac-client-version "1.1.1")
 (def dropwizard-metrics-version "3.2.2")


### PR DESCRIPTION
This version correctly pulls in Bouncy Castle as a "provided" dep,
allowing it to be swapped out in FIPS mode.

It also reintroduces the previously-reverted jolokia bump.
