### PR TITLE
(PE-32193) update ring-middleware to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update ring-middleware to 1.3.1 to add support for referrer-policy headers to be added.
 
 ## [4.7.2]
 - update tk-metrics to 1.4.3, which fixes an issue with its Bouncy Castle dependency that caused issues in FIPS mode. This also reintroduces the jolokia 1.7.0 bump (which was not implicated in the FIPS bug).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+
+## [4.7.3]
 - update ring-middleware to 1.3.1 to add support for referrer-policy headers to be added.
 
 ## [4.7.2]

--- a/project.clj
+++ b/project.clj
@@ -116,7 +116,7 @@
                          [puppetlabs/trapperkeeper-status "1.1.1"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.2.2"]
                          [puppetlabs/structured-logging "0.2.0"]
-                         [puppetlabs/ring-middleware "1.3.0"]
+                         [puppetlabs/ring-middleware "1.3.1"]
                          [puppetlabs/dujour-version-check "0.2.3"]
                          [puppetlabs/comidi "0.3.2"]
                          [puppetlabs/trapperkeeper-comidi-metrics "0.1.1"]


### PR DESCRIPTION
This adds support for a referrer-policy header wrapper to augment
responses with the referrer-policy on a given route.
