### PR TITLE
(TK-494) Bump tk-jetty9 to 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [4.8.0]
+- update tk-jetty9 to 4.2.0, which adds support for TLS 1.3 by default
+
 ## [4.7.3]
 - update ring-middleware to 1.3.1 to add support for referrer-policy headers to be added.
 

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
 (def clj-version "1.10.1")
 (def ks-version "3.1.3")
 (def tk-version "3.1.0")
-(def tk-jetty-version "4.1.8")
+(def tk-jetty-version "4.2.0")
 (def tk-metrics-version "1.4.3")
 (def logback-version "1.2.3")
 (def rbac-client-version "1.1.1")
 (def dropwizard-metrics-version "3.2.2")
 
-(defproject puppetlabs/clj-parent "4.7.4-SNAPSHOT"
+(defproject puppetlabs/clj-parent "4.8.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.


### PR DESCRIPTION
This commit bumps trapperkeeper-webserver-jetty9 to 4.2.0, which includes
support for TLS 1.3 by default.
