### PR TITLE
(maint) Bump tk-jetty9 to 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [4.8.1]
+- update tk-jetty9 to 4.2.1, which adds TLS 1.3 support for FIPS
+
 ## [4.8.0]
 - update tk-jetty9 to 4.2.0, which adds support for TLS 1.3 by default
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.10.1")
 (def ks-version "3.1.3")
 (def tk-version "3.1.0")
-(def tk-jetty-version "4.2.0")
+(def tk-jetty-version "4.2.1")
 (def tk-metrics-version "1.4.3")
 (def logback-version "1.2.3")
 (def rbac-client-version "1.1.1")


### PR DESCRIPTION
This commit bumps trapperkeeper-webserver-jetty9 to 4.2.1, which includes
TLS 1.3 support for FIPS.
