### PR TITLE
(maint) Bump comidi to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update comidi to 0.3.3, which doesn't include any new content, but should clear up false positives from the Snyk security scanner.
 
 ## [4.8.1]
 - update tk-jetty9 to 4.2.1, which adds TLS 1.3 support for FIPS

--- a/project.clj
+++ b/project.clj
@@ -118,7 +118,7 @@
                          [puppetlabs/structured-logging "0.2.0"]
                          [puppetlabs/ring-middleware "1.3.1"]
                          [puppetlabs/dujour-version-check "0.2.3"]
-                         [puppetlabs/comidi "0.3.2"]
+                         [puppetlabs/comidi "0.3.3"]
                          [puppetlabs/trapperkeeper-comidi-metrics "0.1.1"]
                          [puppetlabs/i18n "0.9.2"]
                          [puppetlabs/cljs-dashboard-widgets "0.1.0"]


### PR DESCRIPTION
This commit bumps comidi to 0.3.3, which doesn't include any new content, but
should clear up false positives from the Snyk security scanner.
