### PR TITLE
(SEC-940) update cheshire to version 5.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update cheshire to 5.10.1 to update the jackson dependencies
 
 ## [4.8.3]
 - update puppetlabs/http-client to 1.2.4, which is the public version of the previous security release

--- a/project.clj
+++ b/project.clj
@@ -71,7 +71,7 @@
                          [clj-commons/fs "1.6.307"]
                          [instaparse "1.4.1"]
                          [slingshot "0.12.2"]
-                         [cheshire "5.8.0"]
+                         [cheshire "5.10.1"]
                          [compojure "1.5.0"]
                          [quoin "0.1.2"]
                          [ring/ring-servlet "1.8.2"]


### PR DESCRIPTION
This updates cheshire to version 5.10.1 which contains updated
dependency versions of jackson, and also contains some optimizations
to remove doseq in favor of reduce.  https://github.com/dakrone/cheshire/commit/7040a4a099c3e8ef6c41fc37b78a33e9b507edc3

