### PR TITLE
(maint) update logback to 1.2.7 to address security issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 - update honeysql to 1.0.461 to address SQLi vulnerability and distribute latest version to all consuming projects
+- update logback to 1.2.7 to address https://security.snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-1726923
 
 ## [4.8.4]
 - update cheshire to 5.10.1 to update the jackson dependencies

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
 (def tk-version "3.1.0")
 (def tk-jetty-version "4.2.1")
 (def tk-metrics-version "1.4.3")
-(def logback-version "1.2.3")
+(def logback-version "1.2.7")
 (def rbac-client-version "1.1.1")
 (def dropwizard-metrics-version "3.2.2")
 


### PR DESCRIPTION
Version 1.2.3 of logback is vulnerable to https://security.snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-1726923

This updates the logback version to 1.2.7 which is no longer vulnerable.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
