### PR TITLE
(SEC-941) Update honeysql to latest 1.x series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update honeysql to 1.0.461 to address SQLi vulnerability and distribute latest version to all consuming projects
 
 ## [4.8.4]
 - update cheshire to 5.10.1 to update the jackson dependencies

--- a/project.clj
+++ b/project.clj
@@ -91,7 +91,7 @@
                          [io.dropwizard.metrics/metrics-graphite ~dropwizard-metrics-version]
                          [metrics-clojure "2.10.0"]
                          [org.ow2.asm/asm-all "5.0.3"]
-                         [honeysql "0.6.3"]
+                         [honeysql "1.0.461"]
                          [org.postgresql/postgresql "42.2.14"]
                          [medley "1.0.0"]
 


### PR DESCRIPTION
Pull in security fixes in 1.x series.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
