### PR TITLE
(maint) prepare for 4.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+
+## [4.9.0]
 - update honeysql to 1.0.461 to address SQLi vulnerability and distribute latest version to all consuming projects
 - update logback to 1.2.7 to address https://security.snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-1726923
 

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 (def rbac-client-version "1.1.1")
 (def dropwizard-metrics-version "3.2.2")
 
-(defproject puppetlabs/clj-parent "4.8.5-SNAPSHOT"
+(defproject puppetlabs/clj-parent "4.9.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.


### PR DESCRIPTION
This updates the changelog and release version in preparation of
the 4.9.0 release.  The "Y" was bumped because the honeysql changes
contain breaking changes to some of the interfaces.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
