### PR TITLE
(maint) update logback to 1.2.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
 (def tk-version "3.1.0")
 (def tk-jetty-version "4.2.1")
 (def tk-metrics-version "1.4.3")
-(def logback-version "1.2.7")
+(def logback-version "1.2.9")
 (def rbac-client-version "1.1.1")
 (def dropwizard-metrics-version "3.2.2")
 


### PR DESCRIPTION
This updates logback to 1.2.9 to address the issues described in
https://nvd.nist.gov/vuln/detail/CVE-2021-42550
