### PR TITLE
(PE-33177) Update http-client to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update http-client to 2.0.0 to change default protocols to TLSv1.3 and TLSv1.2, remove TLSv1.1 and TLSv1.
 
 ## [4.10.1]
 - Update ssl-utils to 3.4.1, which makes public the `SSUtils.managerFactoriesToSSLContext` helper.

--- a/project.clj
+++ b/project.clj
@@ -100,7 +100,7 @@
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.12"]
 
-                         [puppetlabs/http-client "1.2.4"]
+                         [puppetlabs/http-client "2.0.0"]
                          [puppetlabs/jdbc-util "1.3.0"]
                          [puppetlabs/typesafe-config "0.2.0"]
                          [puppetlabs/ssl-utils "3.4.1"]


### PR DESCRIPTION
This version changes the default TLS protocols for the HTTP client to be 1.3 and 1.2, and removes 1.1 and 1.0. We are bumping the Y due to the potentially breaking change of removing old TLS protocols from http-client defaults. This enables TLSv1.3 on HTTP clients without having those settings exposed yet in config files for each component (see related tickets in epic https://tickets.puppetlabs.com/browse/PE-33171).
