### PR TITLE
(maint) update jackson to 2.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
+
+## [4.9.1]
 - update jackson to 2.12.6 to address https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698
+- update logback to 1.2.9 to address https://nvd.nist.gov/vuln/detail/CVE-2021-42550
 
 ## [4.9.0]
 - update honeysql to 1.0.461 to address SQLi vulnerability and distribute latest version to all consuming projects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update jackson to 2.12.6 to address https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698
 
 ## [4.9.0]
 - update honeysql to 1.0.461 to address SQLi vulnerability and distribute latest version to all consuming projects

--- a/project.clj
+++ b/project.clj
@@ -39,9 +39,9 @@
                          [ch.qos.logback/logback-access ~logback-version]
                          [net.logstash.logback/logstash-logback-encoder "5.0"]
                          [org.codehaus.janino/janino "3.0.8"]
-                         [com.fasterxml.jackson.core/jackson-core "2.12.1"]
-                         [com.fasterxml.jackson.core/jackson-databind "2.12.1"]
-                         [com.fasterxml.jackson.module/jackson-module-afterburner "2.12.1"]
+                         [com.fasterxml.jackson.core/jackson-core "2.12.6"]
+                         [com.fasterxml.jackson.core/jackson-databind "2.12.6"]
+                         [com.fasterxml.jackson.module/jackson-module-afterburner "2.12.6"]
                          [org.yaml/snakeyaml "1.27"]
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]


### PR DESCRIPTION
This updates jackson to 2.12.6 to address a potential DoS attack
when deserializing JSON content.

see https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698 for
more details.
