### PR TITLE
(SERVER-3135) Update bouncy-castle to 1.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [4.9.2]
+- update bouncy-castle to 1.70, which includes improvements to TLS 1.3 support
+
 ## [4.9.1]
 - update jackson to 2.12.6 to address https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698
 - update logback to 1.2.9 to address https://nvd.nist.gov/vuln/detail/CVE-2021-42550

--- a/project.clj
+++ b/project.clj
@@ -136,7 +136,7 @@
                          [org.bouncycastle/bcpkix-fips "1.0.5"]
                          [org.bouncycastle/bc-fips "1.0.2.1"]
                          [org.bouncycastle/bctls-fips "1.0.11.4"]
-                         [org.bouncycastle/bcpkix-jdk15on "1.68"]]
+                         [org.bouncycastle/bcpkix-jdk15on "1.70"]]
 
   :dependencies [[org.clojure/clojure]]
 


### PR DESCRIPTION
This update brings improved TLS 1.3 support. Note that BC split some
utilities into a new separate jar, `bcutil` that is now also pulled in
as a transitive dependency, in addition to `bcprov`.
