### PR TITLE
(PE-33226) Use pgjdbc fork to fix Bouncy Castle FIPS issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update postgresql jdbc driver to 42.3.1-fipsfix-SNAPSHOT. This is a fork of pgjdbc that fixes the issue that causes problems with bouncycastle. Downstream projects will need to add the artifactory maven repository to their project.clj.
 
 ## [4.9.1]
 - update jackson to 2.12.6 to address https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698

--- a/project.clj
+++ b/project.clj
@@ -92,7 +92,7 @@
                          [metrics-clojure "2.10.0"]
                          [org.ow2.asm/asm-all "5.0.3"]
                          [honeysql "1.0.461"]
-                         [org.postgresql/postgresql "42.2.14"]
+                         [org.postgresql/postgresql "42.3.1-fipsfix-SNAPSHOT"]
                          [medley "1.0.0"]
 
                          [prismatic/plumbing "0.4.2"]


### PR DESCRIPTION
The PostgreSQL JDBC driver overrides the chooseClientAlias method in a way that is incompatible with Bouncy Castle. It causes BC to choose the wrong signing algorithm. This fork fixes the issue. A PR has been submitted to pgjdbc, and hopefully we can switch back once that is accepted.

Downstream projects will need to add https://artifactory.delivery.puppetlabs.net/artifactory/maven (or https://artifactory.delivery.puppetlabs.net/artifactory/maven-snapshots__local if we want to be extra sure this is the only thing pulled in from it) to their list of repositories in project.clj.

Alternatively, a project can check out the pgjdbc fork, check out the `42.3.1-fipsfix` branch, and do `./gradlew publishToMavenLocal -Ppgjdbc.version=42.3.1-fipsfix -PskipJavadoc` to build without having to pull it from artifactory.