### PR TITLE
(maint) Add honeysql 2.x dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- add honeysql 2.x dependency
 
 ## [4.9.2]
 - update bouncy-castle to 1.70, which includes improvements to TLS 1.3 support

--- a/project.clj
+++ b/project.clj
@@ -91,7 +91,9 @@
                          [io.dropwizard.metrics/metrics-graphite ~dropwizard-metrics-version]
                          [metrics-clojure "2.10.0"]
                          [org.ow2.asm/asm-all "5.0.3"]
+                         ;; Remove once all projects are updated to use honeysql 2.x
                          [honeysql "1.0.461"]
+                         [com.github.seancorfield/honeysql "2.2.861"]
                          [org.postgresql/postgresql "42.2.14"]
                          [medley "1.0.0"]
 


### PR DESCRIPTION
This commit adds a dependency on honeysql 2.x, under the group ID
`com.github.seancorfield`. This allows us to depend on both honeysql 2.x and
honeysql 1.x as projects migrate from 1.x to 2.x. honeysql 2.x uses different
namespaces than honeysql 1.x, which will prevent any conflicts from depending
on both versions. Once all projects have migrated, the bare `honeysql`
dependency can be removed.
See https://github.com/seancorfield/honeysql/blob/develop/doc/differences-from-1-x.md