### PR TITLE
(SERVER-3157) Update jruby-utils to 3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
+
+## [4.9.3]
 - add honeysql 2.x dependency
+- update jruby-utils to 3.2.3, which pins a JRuby dependency to avoid a CVE
 
 ## [4.9.2]
 - update bouncy-castle to 1.70, which includes improvements to TLS 1.3 support

--- a/project.clj
+++ b/project.clj
@@ -128,7 +128,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.0.2"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "3.2.2"]
+                         [puppetlabs/jruby-utils "3.2.3"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
This update pins jnr-posix to avoid a CVE.