### PR TITLE
(maint) Update ring-json to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Update ring-json to 0.5.1, which updates dependencies to avoid CVEs and has a small perf improvement
+
 ## [4.9.4]
 - update pgjdbc (org.postgresql/postgresql) to 42.3.2, which fixes a bug in choosing the correct signing algorithm when used with Bouncy Castle, and addresses CVE-2022-21724
 

--- a/project.clj
+++ b/project.clj
@@ -77,7 +77,7 @@
                          [ring/ring-servlet "1.8.2"]
                          [ring/ring-core "1.8.2"]
                          [ring/ring-codec "1.1.2"]
-                         [ring/ring-json "0.5.0"]
+                         [ring/ring-json "0.5.1"]
                          [ring-basic-authentication "1.1.0"]
                          [ring/ring-mock "0.4.0"]
                          [ring/ring-defaults "0.3.2"]


### PR DESCRIPTION
This has some minor dependency updates (which clears up a Snyk warning),
and a potential perf increase.

Note that the snyk warning is getting picked up from a transitive dep (jackson-dataformat) that we override, so we're not actually vulnerable, but I was trying to clear up the "high" severity warnings for code-manager and this is the only one (besides the gettext license).
