### PR TITLE
(maint) update postgres sql driver to 42.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 - update jackson to 2.13.2 to address https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244
+- update postgres sql jdbc driver to 42.3.3 to address https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-2401816
 
 ## [4.9.6]
 - update analytics components to use https://updates.puppet.com by default.

--- a/project.clj
+++ b/project.clj
@@ -94,7 +94,7 @@
                          ;; Remove once all projects are updated to use honeysql 2.x
                          [honeysql "1.0.461"]
                          [com.github.seancorfield/honeysql "2.2.861"]
-                         [org.postgresql/postgresql "42.3.2"]
+                         [org.postgresql/postgresql "42.3.3"]
                          [medley "1.0.0"]
 
                          [prismatic/plumbing "0.4.2"]


### PR DESCRIPTION
This updates the postgres sql driver to address https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-2401816

