### PR TITLE
Add environ 1.1.0 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- add environ 1.1.0 to the managed dependencies
+
 ## [4.9.6]
 - updates analytics components to use https://updates.puppet.com by default.
 - updates ssl-utils to enable copying authority key identifiers from certificates during signing and revocation

--- a/project.clj
+++ b/project.clj
@@ -96,6 +96,7 @@
                          [com.github.seancorfield/honeysql "2.2.861"]
                          [org.postgresql/postgresql "42.3.2"]
                          [medley "1.0.0"]
+                         [environ "1.1.0"]
 
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.12"]


### PR DESCRIPTION
environ is used by both puppetdb and code-manager, and we recently hit a
dependency conflcit between the two in jar-jar.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
