### PR TITLE
(maint) update cheshire to 5.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update cheshire to 5.10.2 to leverage the exclusion of jackson databind  https://github.com/dakrone/cheshire/pull/187
 
 ## [4.9.7]
 - update jackson to 2.13.2 to address https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244

--- a/project.clj
+++ b/project.clj
@@ -71,7 +71,7 @@
                          [clj-commons/fs "1.6.307"]
                          [instaparse "1.4.1"]
                          [slingshot "0.12.2"]
-                         [cheshire "5.10.1"]
+                         [cheshire "5.10.2"]
                          [compojure "1.5.0"]
                          [quoin "0.1.2"]
                          [ring/ring-servlet "1.8.2"]


### PR DESCRIPTION
This updates cheshire from 5.10.1 to 5.10.2, to remove an unneeded dependency on jackson-databind.

https://github.com/dakrone/cheshire/pull/187

jackson-databind is a source of a lot of security issues and requires regular updates.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
