### PR TITLE
(maint) Update kitchensink to 3.2.0 and prepare 4.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+
+## [4.10.0]
 - update kitchensink to 3.2.0 to include the key->str function
 - update cheshire to 5.10.2 to leverage the exclusion of jackson databind  https://github.com/dakrone/cheshire/pull/187
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update kitchensink to 3.2.0 to include the key->str function
 - update cheshire to 5.10.2 to leverage the exclusion of jackson databind  https://github.com/dakrone/cheshire/pull/187
 
 ## [4.9.8]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 (def rbac-client-version "1.1.1")
 (def dropwizard-metrics-version "3.2.2")
 
-(defproject puppetlabs/clj-parent "4.9.9-SNAPSHOT"
+(defproject puppetlabs/clj-parent "4.10.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.10.1")
-(def ks-version "3.1.3")
+(def ks-version "3.2.0")
 (def tk-version "3.1.0")
 (def tk-jetty-version "4.2.1")
 (def tk-metrics-version "1.4.3")


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.