### PR TITLE
(PE-33735) update clojure to 1.11.1, and update clojure deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 ## [Unreleased]
-- update http-client to 2.0.0 to change default protocols to TLSv1.3 and TLSv1.2, remove TLSv1.1 and TLSv1.
 
+- update clojure to 1.11 https://github.com/clojure/clojure/blob/master/changes.md#changes-to-clojure-in-version-1110
+- update clojure/tools.logging to 1.2.4 from 0.4.0 https://github.com/clojure/tools.logging/blob/master/CHANGELOG.md
+- update clojure/tools.cli to 1.0.206 from 0.3.6  https://github.com/clojure/tools.cli/blob/master/CHANGELOG.md
+- update clojure/tools.classpath to 1.0.0 from 0.2.3 https://github.com/clojure/java.classpath/blob/master/CHANGES.md
+- update clojure/java.jdbc to 0.7.12 from 0.7.11 https://github.com/clojure/java.jdbc/blob/master/CHANGES.md
+- update clojure/java.jmx to 1.0.0 from 0.3.4 https://github.com/clojure/java.jmx/commits/master
+- update clojure/core.async to 1.5.648 from 0.4.490 https://github.com/clojure/core.async#changelog
+- update clojure/core.cache to 1.0.225 from 0.7.1  https://github.com/clojure/core.cache#change-log
+- update clojure/core.memoize to 1.0.257 from 0.7.1  https://github.com/clojure/core.memoize#change-log
+- update clojure/tools/reader to 1.3.6 from 1.2.1  https://github.com/clojure/tools.reader/blob/master/CHANGELOG.md
+- update clojure/data.json to 2.4.0 from 0.2.6  https://github.com/clojure/data.json#change-log
+- update clojure/data.priority-map to 1.1.0 from 0.0.9  https://github.com/clojure/data.priority-map/commits/master
+- update http-client to 2.0.0 to change default protocols to TLSv1.3 and TLSv1.2, remove TLSv1.1 and TLSv1.
 - Update jruby-utils to 4.0.0, which updates JRuby to 9.3.4.0.
 
 ## [4.10.1]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def clj-version "1.10.1")
+(def clj-version "1.11.1")
 (def ks-version "3.2.0")
 (def tk-version "3.1.0")
 (def tk-jetty-version "4.2.1")
@@ -16,20 +16,23 @@
 
   :managed-dependencies [[org.clojure/clojure ~clj-version]
                          [org.clojure/clojurescript "1.10.866"]
-                         [org.clojure/tools.logging "0.4.0"]
-                         [org.clojure/tools.cli "0.3.6"]
+                         [org.clojure/tools.logging "1.2.4"]
+                         [org.clojure/tools.cli "1.0.206"]
                          [org.clojure/tools.nrepl "0.2.13"]
                          [org.clojure/tools.macro "0.1.5"]
-                         [org.clojure/java.classpath "0.2.3"]
-                         [org.clojure/java.jdbc "0.7.11"]
-                         [org.clojure/java.jmx "0.3.4"]
-                         [org.clojure/core.async "0.4.490"]
-                         [org.clojure/core.cache "0.7.1"]
-                         [org.clojure/core.memoize "0.7.1"]
-                         [org.clojure/tools.reader "1.2.1"]
+                         [org.clojure/java.classpath "1.0.0"]
+                         [org.clojure/java.jdbc "0.7.12"]
+                         [org.clojure/java.jmx "1.0.0"]
+                         [org.clojure/core.async "1.5.648"]
+                         [org.clojure/core.cache "1.0.225"]
+                         [org.clojure/core.memoize "1.0.257"]
+                         [org.clojure/tools.reader "1.3.6"]
+                         ;; recent attempts to update this resulted in failures to build
+                         ;; Syntax error compiling at (clojure/tools/namespace/file.clj:65:26).
+                         ;; No such var: parse/name-from-ns-decl
                          [org.clojure/tools.namespace "0.2.11"]
-                         [org.clojure/data.json "0.2.6"]
-                         [org.clojure/data.priority-map "0.0.9"]
+                         [org.clojure/data.json "2.4.0"]
+                         [org.clojure/data.priority-map "1.1.0"]
 
                          [org.slf4j/log4j-over-slf4j "1.7.20"]
                          [org.slf4j/slf4j-api "1.7.20"]


### PR DESCRIPTION
This updates clojure to 1.11.1, and updates the various clojure tools
and data deps that are specified in clj-parent. Most hadn't been updated
since 2018.
