### PR TITLE
(SERVER-2944) Bump ssl-utils to 3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [4.10.1]
+- Update ssl-utils to 3.4.1, which makes public the `SSUtils.managerFactoriesToSSLContext` helper.
+
 ## [4.10.0]
 - update kitchensink to 3.2.0 to include the key->str function
 - update cheshire to 5.10.2 to leverage the exclusion of jackson databind  https://github.com/dakrone/cheshire/pull/187

--- a/project.clj
+++ b/project.clj
@@ -103,7 +103,7 @@
                          [puppetlabs/http-client "1.2.4"]
                          [puppetlabs/jdbc-util "1.3.0"]
                          [puppetlabs/typesafe-config "0.2.0"]
-                         [puppetlabs/ssl-utils "3.4.0"]
+                         [puppetlabs/ssl-utils "3.4.1"]
                          [puppetlabs/clj-ldap "0.3.0"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
