### PR TITLE
(maint) Bump jruby-utils to 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [5.0.1]
+- update jruby-utils to 4.0.1, which unpins jnr-posix in jruby-deps to resolve a pedantic dependency conflict
+
 ## [5.0.0]
 - update clojure to 1.11 https://github.com/clojure/clojure/blob/master/changes.md#changes-to-clojure-in-version-1110
 - update clojure/tools.logging to 1.2.4 from 0.4.0 https://github.com/clojure/tools.logging/blob/master/CHANGELOG.md

--- a/project.clj
+++ b/project.clj
@@ -131,7 +131,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.1.1"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "4.0.0"]
+                         [puppetlabs/jruby-utils "4.0.1"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
This unpins a dependency that was causing pedantic conflicts.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
