### PR TITLE
(PE-34097) update tk-jetty9 to 4.3.1, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [4.11.1]
+- update tk-jetty9 to 4.3.1, which includes Jetty 9.4.48
+
 ## [4.11.0]
 - Update tk-jetty9 to 4.3.0, which includes Jetty 9.4.44 and updates to the default cipher suites.
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.10.1")
 (def ks-version "3.2.0")
 (def tk-version "3.1.0")
-(def tk-jetty-version "4.3.0")
+(def tk-jetty-version "4.3.1")
 (def tk-metrics-version "1.4.3")
 (def logback-version "1.2.9")
 (def rbac-client-version "1.1.1")


### PR DESCRIPTION
This updates tk-jetty9 to 4.3.1, which includes jettty-9.4.48, which
has:

https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.48.v20220622
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.47.v20220610
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.46.v20220331
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.45.v20220203

It also prepares for a new release.