### PR TITLE
(maint) Bump rbac-client to support updated parse-subject function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+
+## [5.2.0]
 - Update clj-rbac-client to 1.1.3, which includes an updated parse-subject function
 
 ## [5.1.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Update clj-rbac-client to 1.1.3, which includes an updated parse-subject function
 
 ## [5.1.1]
 - update tk-jetty9 to 4.3.1 which includes Jetty 9.4.48

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 (def rbac-client-version "1.1.3")
 (def dropwizard-metrics-version "3.2.2")
 
-(defproject puppetlabs/clj-parent "5.1.2-SNAPSHOT"
+(defproject puppetlabs/clj-parent "5.2.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "4.3.1")
 (def tk-metrics-version "1.4.3")
 (def logback-version "1.2.9")
-(def rbac-client-version "1.1.1")
+(def rbac-client-version "1.1.3")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "5.1.2-SNAPSHOT"


### PR DESCRIPTION
The rbac-client has been updated with a new version of parse-subject to normalize subjects when interacting with the rbac service.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
