### PR TITLE
(maint) Update honeysql (v2) to 2.3.911

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Update honeysql (v2) to 2.3.911, which includes support for postgres json operators
+
 ## [5.2.1]
 - update postgres driver to 42.4.1 to address CVE-2022-31197
 

--- a/project.clj
+++ b/project.clj
@@ -96,7 +96,7 @@
                          [org.ow2.asm/asm-all "5.0.3"]
                          ;; Remove once all projects are updated to use honeysql 2.x
                          [honeysql "1.0.461"]
-                         [com.github.seancorfield/honeysql "2.2.861"]
+                         [com.github.seancorfield/honeysql "2.3.911"]
                          [org.postgresql/postgresql "42.4.1"]
                          [medley "1.0.0"]
 


### PR DESCRIPTION
Update honeysql v2 to latest. To upgrade PuppetDB from honeysql v1, we
need to use some of the postgres operators added in 2.2.891
