### PR TITLE
(PE-34255) update postgres driver version to 42.4.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+
+## [4.11.2]
 - update postgres driver to 42.4.1 to address CVE-2022-31197
 
 ## [4.11.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update postgres driver to 42.4.1 to address CVE-2022-31197
 
 ## [4.11.1]
 - update tk-jetty9 to 4.3.1, which includes Jetty 9.4.48

--- a/project.clj
+++ b/project.clj
@@ -94,7 +94,7 @@
                          ;; Remove once all projects are updated to use honeysql 2.x
                          [honeysql "1.0.461"]
                          [com.github.seancorfield/honeysql "2.2.861"]
-                         [org.postgresql/postgresql "42.3.3"]
+                         [org.postgresql/postgresql "42.4.1"]
                          [medley "1.0.0"]
 
                          [prismatic/plumbing "0.4.2"]


### PR DESCRIPTION
This update to the postgres driver resolves CVE-2022-31197 as well
as adds support for 64K indexed parameters. The prior version only
supported 32K.

This also prepares for the release in a separate commit.
