### PR TITLE
(PE-34255)  update postgres driver version to 42.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+
+## [5.2.1]
 - update postgres driver to 42.4.1 to address CVE-2022-31197
 
 ## [5.2.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update postgres driver to 42.4.1 to address CVE-2022-31197
 
 ## [5.2.0]
 - Update clj-rbac-client to 1.1.3, which includes an updated parse-subject function

--- a/project.clj
+++ b/project.clj
@@ -97,7 +97,7 @@
                          ;; Remove once all projects are updated to use honeysql 2.x
                          [honeysql "1.0.461"]
                          [com.github.seancorfield/honeysql "2.2.861"]
-                         [org.postgresql/postgresql "42.3.3"]
+                         [org.postgresql/postgresql "42.4.1"]
                          [medley "1.0.0"]
 
                          [prismatic/plumbing "0.4.2"]


### PR DESCRIPTION
This update to the postgres driver resolves CVE-2022-31197 as well
as adds support for 64K indexed parameters. The prior version only
supported 32K.

It also prepares for the subsequent release.