### PR TITLE
(PE-34579) Manage bctls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [5.2.3]
+- Add org.bouncycastle/bctls-jdk15on, which was previously being managed per-project
+
 ## [5.2.2]
 - Update honeysql (v2) to 2.3.911, which includes support for postgres json operators
 

--- a/project.clj
+++ b/project.clj
@@ -141,7 +141,8 @@
                          [org.bouncycastle/bcpkix-fips "1.0.5"]
                          [org.bouncycastle/bc-fips "1.0.2.1"]
                          [org.bouncycastle/bctls-fips "1.0.11.4"]
-                         [org.bouncycastle/bcpkix-jdk15on "1.70"]]
+                         [org.bouncycastle/bcpkix-jdk15on "1.70"]
+                         [org.bouncycastle/bctls-jdk15on "1.70"]]
 
   :dependencies [[org.clojure/clojure]]
 


### PR DESCRIPTION
This commit adds a dependency on bouncycastle's TLS library. Previously, we were hard-coding the dependency version in each project that uses it. This allows us to manage the version centrally.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
