### PR TITLE
(maint) update bouncy-castle fips dependencies to the latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- update the bouncycastle fips versions to bcpkix-fips 1.0.6, bc-fips 1.0.2.3, bctls-fips 1.0.13 so the FOSS builds match
 
 ## [5.2.5]
 - roll bouncycastle jdk18on dependencies back to 1.71 because 1.72 is not currently on maven central.

--- a/project.clj
+++ b/project.clj
@@ -138,9 +138,9 @@
                          ;; for BC (ie, clj-parent manages these versions for
                          ;; dev and FOSS, PE is managed via packages):
                          ;; https://github.com/puppetlabs/bouncy-castle-vanagon
-                         [org.bouncycastle/bcpkix-fips "1.0.5"]
-                         [org.bouncycastle/bc-fips "1.0.2.1"]
-                         [org.bouncycastle/bctls-fips "1.0.11.4"]
+                         [org.bouncycastle/bcpkix-fips "1.0.6"]
+                         [org.bouncycastle/bc-fips "1.0.2.3"]
+                         [org.bouncycastle/bctls-fips "1.0.13"]
                          [org.bouncycastle/bcpkix-jdk15on "1.70"]
                          [org.bouncycastle/bctls-jdk15on "1.70"]
                          [org.bouncycastle/bcprov-jdk15on "1.70"]


### PR DESCRIPTION
In an effort to keep the bouncy-castle FIPS library versions up to date, this updates:
```
bcpkix-fips 1.0.6
bc-fips 1.0.2.3
bctls-fips 1.0.13
```

