### PR TITLE
(maint) update dependencies, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [5.2.7]
+- update trapperkeeper-metrics, clj-http-client, trapperkeeper-webserver-jetty9, dujour and the analytics client to new versions that are based on `clj-parent 5.2.6`, and shift to the `18on` version of bouncycastle from the `15on` versions.
+
 ## [5.2.6]
 - update the bouncycastle fips versions to bcpkix-fips 1.0.6, bc-fips 1.0.2.3, bctls-fips 1.0.13 so the FOSS builds match
 

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
 (def clj-version "1.11.1")
 (def ks-version "3.2.0")
 (def tk-version "3.1.0")
-(def tk-jetty-version "4.3.1")
-(def tk-metrics-version "1.4.3")
+(def tk-jetty-version "4.4.0")
+(def tk-metrics-version "1.5.0")
 (def logback-version "1.2.9")
 (def rbac-client-version "1.1.3")
 (def dropwizard-metrics-version "3.2.2")
@@ -103,7 +103,7 @@
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.12"]
 
-                         [puppetlabs/http-client "2.0.0"]
+                         [puppetlabs/http-client "2.1.0"]
                          [puppetlabs/jdbc-util "1.3.0"]
                          [puppetlabs/typesafe-config "0.2.0"]
                          [puppetlabs/ssl-utils "3.4.1"]
@@ -122,14 +122,14 @@
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.2.2"]
                          [puppetlabs/structured-logging "0.2.0"]
                          [puppetlabs/ring-middleware "1.3.1"]
-                         [puppetlabs/dujour-version-check "0.3.1"]
+                         [puppetlabs/dujour-version-check "1.0.0"]
                          [puppetlabs/comidi "1.0.0"]
                          [puppetlabs/trapperkeeper-comidi-metrics "0.1.1"]
                          [puppetlabs/i18n "0.9.2"]
                          [puppetlabs/cljs-dashboard-widgets "0.1.0"]
                          [puppetlabs/rbac-client ~rbac-client-version]
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
-                         [puppetlabs/analytics-client "1.1.1"]
+                         [puppetlabs/analytics-client "1.2.0"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
                          [puppetlabs/jruby-utils "4.0.1"]
 


### PR DESCRIPTION
This updates:
* `trapperkeeper-webserver-jetty9` to `4.4.0`
* `trapperkeeper-metrics` to `1.5.0`
* `clj-http-client1` to `2.1.0`
* `dujour-version-check` to `1.0.0`
* `analytics-client` to `1.2.0`

in order to remve the dependency on the `15on` versions of the bouncycastle libraries, in favor of the `18on` versions.

It also prepares for a new release.
