### PR TITLE
(maint) update ssl-utls, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+##[5.2.8]
+- update ssl-utils to 3.5.0 to use the `18on` version of the bouncycastle libraries instead of the recently renamed `15on`
+
 ## [5.2.7]
 - update trapperkeeper-metrics, clj-http-client, trapperkeeper-webserver-jetty9, dujour and the analytics client to new versions that are based on `clj-parent 5.2.6`, and shift to the `18on` version of bouncycastle from the `15on` versions.
 

--- a/project.clj
+++ b/project.clj
@@ -106,7 +106,7 @@
                          [puppetlabs/http-client "2.1.0"]
                          [puppetlabs/jdbc-util "1.3.0"]
                          [puppetlabs/typesafe-config "0.2.0"]
-                         [puppetlabs/ssl-utils "3.4.1"]
+                         [puppetlabs/ssl-utils "3.5.0"]
                          [puppetlabs/clj-ldap "0.3.0"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]


### PR DESCRIPTION
This updates ssl-utils to the recently released `3.5.0` which changes the dependency on to the `18on` version of bouncycastle instead of the recently renamed `15on` series.

