### PR TITLE
(PE-34652) add stylefruits/gniazdo 1.2.1 as a managed dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
+- add stylefruits/gniazdo to avoid version conflicts in dependent projects
 
-##[5.2.8]
+## [5.2.8]
 - update ssl-utils to 3.5.0 to use the `18on` version of the bouncycastle libraries instead of the recently renamed `15on`
 
 ## [5.2.7]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+
+## [5.2.9]
 - add stylefruits/gniazdo to avoid version conflicts in dependent projects
 
 ## [5.2.8]

--- a/project.clj
+++ b/project.clj
@@ -99,9 +99,9 @@
                          [com.github.seancorfield/honeysql "2.3.911"]
                          [org.postgresql/postgresql "42.4.1"]
                          [medley "1.0.0"]
-
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.12"]
+                         [stylefruits/gniazdo "1.2.1"]
 
                          [puppetlabs/http-client "2.1.0"]
                          [puppetlabs/jdbc-util "1.3.0"]


### PR DESCRIPTION
This adds `stylefruits/gniazdo` to the set of dependencies managed with clj-parent. Several projects define the version of `stylefruits/gniazdo` used and this causes dependency conflicts downstream.

