### PR TITLE
(PE-34658) Bump tk-jetty9 to 4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [5.2.10]
+- bump trapperkeeper-webserver-jetty9 to 4.4.1, which makes use of the stylefruits/gniazdo version from this project.
+
 ## [5.2.9]
 - add stylefruits/gniazdo to avoid version conflicts in dependent projects
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.11.1")
 (def ks-version "3.2.0")
 (def tk-version "3.1.0")
-(def tk-jetty-version "4.4.0")
+(def tk-jetty-version "4.4.1")
 (def tk-metrics-version "1.5.0")
 (def logback-version "1.2.9")
 (def rbac-client-version "1.1.3")


### PR DESCRIPTION
This commit bumps the version of trapperkeeper-webserver-jetty9 to a version that makes use of the `stylefruits/gniazdo` version defined in this project, rather than pinning its own version.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
