### PR TITLE
(maint) Bump rbac-client to support optional subject identity provider id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [5.2.12]
+- Update clj-rbac-client to 1.1.4, adds optional identity provider id to RBAC subject
+
 ## [5.2.11]
 - Update snakeyaml to 1.33 to address CVE-2022-38751
 - Update jackson libraries to 2.13.4 to address https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def tk-jetty-version "4.4.1")
 (def tk-metrics-version "1.5.0")
 (def logback-version "1.2.9")
-(def rbac-client-version "1.1.3")
+(def rbac-client-version "1.1.4")
 (def dropwizard-metrics-version "3.2.2")
 
 (defproject puppetlabs/clj-parent "5.2.12-SNAPSHOT"


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
