### PR TITLE
(maint) Update clj-http-client to 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [5.2.13]
+- Update clj-http-client to 2.1.1, fixes connection reuse when using an SSL client certificate
+
 ## [5.2.12]
 - Update clj-rbac-client to 1.1.4, adds optional identity provider id to RBAC subject
 

--- a/project.clj
+++ b/project.clj
@@ -103,7 +103,7 @@
                          [prismatic/schema "1.1.12"]
                          [stylefruits/gniazdo "1.2.1"]
 
-                         [puppetlabs/http-client "2.1.0"]
+                         [puppetlabs/http-client "2.1.1"]
                          [puppetlabs/jdbc-util "1.3.0"]
                          [puppetlabs/typesafe-config "0.2.0"]
                          [puppetlabs/ssl-utils "3.5.0"]


### PR DESCRIPTION
This fixes a bug that prevented connection reuse when using an SSL
client certificate.