### PR TITLE
(PE-34664) Update jackson libraries to 2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [5.2.14]
+- Update jackson libraries to 2.14.0 to resolve CVE-2022-42003 (https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426)
+
 ## [5.2.13]
 - Update clj-http-client to 2.1.1, fixes connection reuse when using an SSL client certificate
 

--- a/project.clj
+++ b/project.clj
@@ -42,9 +42,9 @@
                          [ch.qos.logback/logback-access ~logback-version]
                          [net.logstash.logback/logstash-logback-encoder "5.0"]
                          [org.codehaus.janino/janino "3.0.8"]
-                         [com.fasterxml.jackson.core/jackson-core "2.13.4"]
-                         [com.fasterxml.jackson.core/jackson-databind "2.13.4"]
-                         [com.fasterxml.jackson.module/jackson-module-afterburner "2.13.4"]
+                         [com.fasterxml.jackson.core/jackson-core "2.14.0"]
+                         [com.fasterxml.jackson.core/jackson-databind "2.14.0"]
+                         [com.fasterxml.jackson.module/jackson-module-afterburner "2.14.0"]
                          [org.yaml/snakeyaml "1.33"]
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]


### PR DESCRIPTION
Resolves https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
