### PR TITLE
Fix ini4j CVE-2022-41404 and postgresql CVE-2022-41946

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+- Upgrade postgresql driver to 42.4.3 to address
+  [CVE-2022-41946](https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-562r-vg33-8x8h#event-84471)
 ## [5.2.15]
 - Update jruby-utils which brings in jruby-deps 9.3.9.0-1 & JRuby 9.3.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Upgrade kitchensink 3.2.1 for ini4j 0.5.4 to address CVE-2022-41404.
 - Upgrade postgresql driver to 42.4.3 to address
   [CVE-2022-41946](https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-562r-vg33-8x8h#event-84471)
 ## [5.2.15]

--- a/project.clj
+++ b/project.clj
@@ -97,7 +97,7 @@
                          ;; Remove once all projects are updated to use honeysql 2.x
                          [honeysql "1.0.461"]
                          [com.github.seancorfield/honeysql "2.3.911"]
-                         [org.postgresql/postgresql "42.4.1"]
+                         [org.postgresql/postgresql "42.4.3"]
                          [medley "1.0.0"]
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.12"]

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.11.1")
-(def ks-version "3.2.0")
+(def ks-version "3.2.1")
 (def tk-version "3.1.0")
 (def tk-jetty-version "4.4.1")
 (def tk-metrics-version "1.5.0")


### PR DESCRIPTION
The 4.x fix is #371