### PR TITLE
(maint) update tk-auth to 2.0.0 which contains updated dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [unreleased]
+## update tk-auth to 2.0.0 with updated dependencies
 
 ## [5.3.0]
 - Upgrade trapperkeeper to 3.2.1 to fix crashes on SIGHUP

--- a/project.clj
+++ b/project.clj
@@ -117,7 +117,7 @@
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version]
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version :classifier "test"]
                          [puppetlabs/trapperkeeper-scheduler "1.1.3"]
-                         [puppetlabs/trapperkeeper-authorization "1.0.0"]
+                         [puppetlabs/trapperkeeper-authorization "2.0.0"]
                          [puppetlabs/trapperkeeper-status "1.1.1"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.2.2"]
                          [puppetlabs/structured-logging "0.2.0"]


### PR DESCRIPTION
This updates tk-auth to 2.0.0 which updated the clj-parent version, and changed the dependencies so it no longer has a hard depenency on ring-mock but does reflect its hard dependency on ring-codec.

