### PR TITLE
(PE-35357) Upgrade Hikari CP to 5.x series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.3.1]
+- Upgrade HikariCP to 5.0.1 from 2.7.4.
+
 ## [5.3.0]
 - Upgrade trapperkeeper to 3.2.1 to fix crashes on SIGHUP
   [PDB-5215)](https://tickets.puppetlabs.com/browse/PDB-5215)

--- a/project.clj
+++ b/project.clj
@@ -70,7 +70,7 @@
                          [clj-time "0.11.0"]
                          [clj-commons/clj-yaml "0.7.2"]
                          [clj-stacktrace "0.2.8"]
-                         [com.zaxxer/HikariCP "2.7.4"]
+                         [com.zaxxer/HikariCP "5.0.1"]
                          [clj-commons/fs "1.6.307"]
                          [instaparse "1.4.1"]
                          [slingshot "0.12.2"]
@@ -104,7 +104,7 @@
                          [stylefruits/gniazdo "1.2.1"]
 
                          [puppetlabs/http-client "2.1.1"]
-                         [puppetlabs/jdbc-util "1.3.0"]
+                         [puppetlabs/jdbc-util "1.4.0"]
                          [puppetlabs/typesafe-config "0.2.0"]
                          [puppetlabs/ssl-utils "3.5.0"]
                          [puppetlabs/clj-ldap "0.4.0"]


### PR DESCRIPTION
Pending releasing jdbc-util 1.4.0 after https://github.com/puppetlabs/jdbc-util/pull/88/ is merged
