### PR TITLE
Revert "(PE-34726) Bump logback version to 1.3.5"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.3.3]
+- Revert logback upgrade in 5.3.2 until compatibility issue is resolved.
+
 ## [5.3.2]
 - Upgrade logback to 1.3.5 from 1.2.9, upgrade logback dependencies to 2.0.6.
 - Upgrade trapperkeeper to 3.3.0 from 3.2.1.

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
 (def clj-version "1.11.1")
 (def ks-version "3.2.1")
-(def tk-version "3.3.0")
+(def tk-version "3.2.1")
 (def tk-jetty-version "4.4.1")
 (def tk-metrics-version "1.5.0")
-(def logback-version "1.3.5")
+(def logback-version "1.2.9")
 (def rbac-client-version "1.1.4")
 (def dropwizard-metrics-version "3.2.2")
 
@@ -34,9 +34,9 @@
                          [org.clojure/data.json "2.4.0"]
                          [org.clojure/data.priority-map "1.1.0"]
 
-                         [org.slf4j/slf4j-api "2.0.6"]
-                         [org.slf4j/log4j-over-slf4j "2.0.6"]
-                         [org.slf4j/jul-to-slf4j "2.0.6"]
+                         [org.slf4j/log4j-over-slf4j "1.7.20"]
+                         [org.slf4j/slf4j-api "1.7.20"]
+                         [org.slf4j/jul-to-slf4j "1.7.20"]
                          [ch.qos.logback/logback-classic ~logback-version]
                          [ch.qos.logback/logback-core ~logback-version]
                          [ch.qos.logback/logback-access ~logback-version]


### PR DESCRIPTION
This reverts commit df4ce0ebe8778d8d314fdb8dfc7ff9c5094ace0c due to compatibility issue with logback 1.3.x.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
