### PR TITLE
(PE-35872) update trapperkeeper jetty 9 to 4.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.3.4]
+- update tk-jetty-9 to 4.4.2 to resolve CVE-2023-26048
+
 ## [5.3.3]
 - Revert logback upgrade in 5.3.2 until compatibility issue is resolved.
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.11.1")
 (def ks-version "3.2.1")
 (def tk-version "3.2.1")
-(def tk-jetty-version "4.4.1")
+(def tk-jetty-version "4.4.2")
 (def tk-metrics-version "1.5.0")
 (def logback-version "1.2.9")
 (def rbac-client-version "1.1.4")


### PR DESCRIPTION
This updates tk-jetty9 to 4.4.2 that includes the latest version of jetty to address CVE-2023-26048.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
