### PR TITLE
(maint) update tk-webserver-j9 to v4.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.3.5]
+- update tk-jetty-9 to 4.4.3 to maintain compatibility with FOSS 7.x
+
 ## [5.3.4]
 - update tk-jetty-9 to 4.4.2 to resolve CVE-2023-26048
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.11.1")
 (def ks-version "3.2.1")
 (def tk-version "3.2.1")
-(def tk-jetty-version "4.4.2")
+(def tk-jetty-version "4.4.3")
 (def tk-metrics-version "1.5.0")
 (def logback-version "1.2.9")
 (def rbac-client-version "1.1.4")


### PR DESCRIPTION
In a previous commit [1], trapperkeeper-webserver-jetty9 was updated to v4.4.2 to address CVE-2023-26048 and CVE-2023-26049. That version was erroneously built with jdk11. This commit updates tk-webserver-j9 to a new release built with JDK8 to maintain compatibility with FOSS 7.x.

[1]: 224e551c31b2dc7e1166464e5f58a1b32bc9e672

