### PR TITLE
(PE-34960) Update clj-parent with jruby 9.4 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.4.0]
+- Update jruby-utils which brings in jruby-deps 9.4.2.0-1 & Jruby 9.4.2.0
+
 ## [5.3.5]
 - update tk-jetty-9 to 4.4.3 to maintain compatibility with FOSS 7.x
 

--- a/project.clj
+++ b/project.clj
@@ -131,7 +131,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.2.0"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "4.0.3"]
+                         [puppetlabs/jruby-utils "5.0.0"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
