### PR TITLE
(PE-35979) bump logback to latest 1.2.x series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [unreleased]
+- Update logback to 1.2.12, to fix logging issues relative to jetty 10
 
 ## [5.4.0]
 - Update jruby-utils which brings in jruby-deps 9.4.2.0-1 & Jruby 9.4.2.0

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
 (def tk-version "3.2.1")
 (def tk-jetty-version "4.4.3")
 (def tk-metrics-version "1.5.0")
-(def logback-version "1.2.9")
+(def logback-version "1.2.12")
 (def rbac-client-version "1.1.4")
 (def dropwizard-metrics-version "3.2.2")
 


### PR DESCRIPTION
This updates logback to 1.2.12, which is the latest version in the 1.2 series to address issues with logging and jetty 10.
