### PR TITLE
(maint) update version to 6.x series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [unreleased]
 
-## [5.4.0]
+## [6.0.0]
+- update versioning for jruby update.  5.x branch created from 5.3.5
+
+## [5.3.6] 
 - Update jruby-utils which brings in jruby-deps 9.4.2.0-1 & Jruby 9.4.2.0
 
 ## [5.3.5]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 (def rbac-client-version "1.1.4")
 (def dropwizard-metrics-version "3.2.2")
 
-(defproject puppetlabs/clj-parent "5.3.7-SNAPSHOT"
+(defproject puppetlabs/clj-parent "6.0.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.


### PR DESCRIPTION
This updates the version to 6.x to correspond to the new jruby version which has compatibility for Ruby 3.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
