### PR TITLE
(maint) update kitchensink and prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [unreleased]
+- Update clj-kitchensink to 3.2.3 to bring in new time conversion and version comparison functions
 - Update logback to 1.2.12, to fix logging issues relative to jetty 10
 
 ## [6.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [unreleased]
+
+# [6.0.1]
 - Update clj-kitchensink to 3.2.3 to bring in new time conversion and version comparison functions
 - Update logback to 1.2.12, to fix logging issues relative to jetty 10
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.11.1")
-(def ks-version "3.2.1")
+(def ks-version "3.2.3")
 (def tk-version "3.2.1")
 (def tk-jetty-version "4.4.3")
 (def tk-metrics-version "1.5.0")


### PR DESCRIPTION
This updates clj-kitchensink to bring in some new java.time conversion
functions since clj-time is deprecated, as is joda time.  Additionally
it adds a function for comparing version strings based on the puppet 'versioncmp'.

Finally clj-kondo and eastwood were applied and reflection issues
were addressed.