### PR TITLE
(PE-36370) update trapperkeeper to 4.0, remove clj-yaml ; prepare for release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [unreleased]
+- BREAKING CHANGE: update trapperkeeper to 4.0.0 which removes yaml config support and remove clj-yaml
 
 # [6.0.1]
 - Update clj-kitchensink to 3.2.3 to bring in new time conversion and version comparison functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [unreleased]
+
+# [7.0.0]
 - BREAKING CHANGE: update trapperkeeper to 4.0.0 which removes yaml config support and remove clj-yaml
 
 # [6.0.1]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 (def rbac-client-version "1.1.4")
 (def dropwizard-metrics-version "3.2.2")
 
-(defproject puppetlabs/clj-parent "6.0.2-SNAPSHOT"
+(defproject puppetlabs/clj-parent "7.0.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.11.1")
 (def ks-version "3.2.3")
-(def tk-version "3.2.1")
+(def tk-version "4.0.0")
 (def tk-jetty-version "4.4.3")
 (def tk-metrics-version "1.5.0")
 (def logback-version "1.2.12")
@@ -68,7 +68,6 @@
                          [nrepl/nrepl "0.6.0"]
                          [bidi "2.1.3"]
                          [clj-time "0.11.0"]
-                         [clj-commons/clj-yaml "0.7.2"]
                          [clj-stacktrace "0.2.8"]
                          [com.zaxxer/HikariCP "5.0.1"]
                          [clj-commons/fs "1.6.307"]


### PR DESCRIPTION
This updates trapperkeeper to 4.0 and removes clj-yaml which has
known security issues.

In a separate commit:  
This is a prep for the 7.0.0 release, which contains breaking changes
in trapperkeeper -- it removes support for yaml based configuration
files.