### PR TITLE
(PE-36390) remove ring-defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [unreleased]
+- remove use of ring-defaults, update tk-metrics and tk-status to versions without use of ring-defaults
 
 ## [5.3.7]
 - branched from 5.3.5 and updated version to 5.3.7 to avoid 5.3.6 which had an unintented jruby bump

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "3.2.1")
 (def tk-version "3.2.1")
 (def tk-jetty-version "4.4.3")
-(def tk-metrics-version "1.5.0")
+(def tk-metrics-version "1.5.1")
 (def logback-version "1.2.9")
 (def rbac-client-version "1.1.4")
 (def dropwizard-metrics-version "3.2.2")
@@ -83,7 +83,6 @@
                          [ring/ring-json "0.5.1"]
                          [ring-basic-authentication "1.1.0"]
                          [ring/ring-mock "0.4.0"]
-                         [ring/ring-defaults "0.3.2"]
                          [stencil "0.5.0"]
                          [beckon "0.1.1"]
                          [hiccup "1.0.5"]
@@ -118,7 +117,7 @@
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version :classifier "test"]
                          [puppetlabs/trapperkeeper-scheduler "1.1.3"]
                          [puppetlabs/trapperkeeper-authorization "1.0.0"]
-                         [puppetlabs/trapperkeeper-status "1.1.1"]
+                         [puppetlabs/trapperkeeper-status "1.1.2"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.2.2"]
                          [puppetlabs/structured-logging "0.2.0"]
                          [puppetlabs/ring-middleware "1.3.1"]


### PR DESCRIPTION
This commit updates trapperkeeper-metrics and trapperkeeper-status to new versions that remove the use of ring-defaults and removes ring-defaults, which is no longer actively maintained.

Commits for that work in tk-metrics [1] and tk-status [2]

[1]: https://github.com/puppetlabs/trapperkeeper-metrics/commit/f5cf1040b7d8cbb8a5f4601b130ff60e6fb7153d
[2]: https://github.com/puppetlabs/trapperkeeper-status/commit/85a031c9d98a941e3160d1e1767bcf6942836fbe

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
