### PR TITLE
(PE-36390) remove ring defaults, prepare for 7.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [unreleased]
+
+# [7.0.1]
 - remove use of ring-defaults, update tk-metrics and tk-status to versions without use of ring-defaults
 
 # [7.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [unreleased]
+- remove use of ring-defaults, update tk-metrics and tk-status to versions without use of ring-defaults
 
 # [7.0.0]
 - BREAKING CHANGE: update trapperkeeper to 4.0.0 which removes yaml config support and remove clj-yaml
@@ -10,7 +11,7 @@
 ## [6.0.0]
 - update versioning for jruby update.  5.x branch created from 5.3.5
 
-## [5.3.6] 
+## [5.3.6]
 - Update jruby-utils which brings in jruby-deps 9.4.2.0-1 & Jruby 9.4.2.0
 
 ## [5.3.5]

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "3.2.3")
 (def tk-version "4.0.0")
 (def tk-jetty-version "4.4.3")
-(def tk-metrics-version "1.5.0")
+(def tk-metrics-version "1.5.1")
 (def logback-version "1.2.12")
 (def rbac-client-version "1.1.4")
 (def dropwizard-metrics-version "3.2.2")
@@ -82,7 +82,6 @@
                          [ring/ring-json "0.5.1"]
                          [ring-basic-authentication "1.1.0"]
                          [ring/ring-mock "0.4.0"]
-                         [ring/ring-defaults "0.3.2"]
                          [stencil "0.5.0"]
                          [beckon "0.1.1"]
                          [hiccup "1.0.5"]
@@ -117,7 +116,7 @@
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version :classifier "test"]
                          [puppetlabs/trapperkeeper-scheduler "1.1.3"]
                          [puppetlabs/trapperkeeper-authorization "1.0.0"]
-                         [puppetlabs/trapperkeeper-status "1.1.1"]
+                         [puppetlabs/trapperkeeper-status "1.1.2"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.2.2"]
                          [puppetlabs/structured-logging "0.2.0"]
                          [puppetlabs/ring-middleware "1.3.1"]


### PR DESCRIPTION
(PE-36390) remove ring-defaults

This commit updates trapperkeeper-metrics and trapperkeeper-status
to new versions that remove the use of ring-defaults and removes
ring-defaults, which is no longer actively maintained.

Commits for that work in tk-metrics [1] and tk-status [2]

[1]: f5cf1040b7d8cbb8a5f4601b130ff60e6fb7153d
[2]: 85a031c9d98a941e3160d1e1767bcf6942836fbe
