### PR TITLE
(PE-36490) update jvm-ssl-utils, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [unreleased]
 
+# [7.0.2]
+- update jvm-ssl-utils to bring in the ability to create CSRs (in the simple namepace) with attributes
+- update jvm-ssl-utils to bring in the ability to extract attributes from CSRs
+
 # [7.0.1]
 - remove use of ring-defaults, update tk-metrics and tk-status to versions without use of ring-defaults
 

--- a/project.clj
+++ b/project.clj
@@ -104,7 +104,7 @@
                          [puppetlabs/http-client "2.1.1"]
                          [puppetlabs/jdbc-util "1.4.0"]
                          [puppetlabs/typesafe-config "0.2.0"]
-                         [puppetlabs/ssl-utils "3.5.0"]
+                         [puppetlabs/ssl-utils "3.5.1"]
                          [puppetlabs/clj-ldap "0.4.0"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]


### PR DESCRIPTION
This updates jvm-ssl-utils to 3.5.1, which allows the addition of attributes to Certificate Signing Requests made through the "simple" namespace as well as a function to extract the attributes from the CSR.

Additionally, it updates the CHANGELOG in preparation for a new release.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
