### PR TITLE
(PE-36476) update tk to 3.3.1 and prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.3.9]
+- update trapperkeeper to 3.3.1 to remove the dependency on clj-yaml
+
 ## [5.3.8]
 - remove use of ring-defaults, update tk-metrics and tk-status to versions without use of ring-defaults
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.11.1")
 (def ks-version "3.2.1")
-(def tk-version "3.2.1")
+(def tk-version "3.3.1")
 (def tk-jetty-version "4.4.3")
 (def tk-metrics-version "1.5.1")
 (def logback-version "1.2.9")


### PR DESCRIPTION
This updates trapperkeeper to 3.3.1 to remove its dependency on clj-yaml.

In addition, this updates the changelog in preparation for release.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
