### PR TITLE
(maint) update snakeyaml to 2.0 from 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [unreleased]
 
+- update snakeyaml to 2.0 from 1.3.3 to address CVE-2022-1471
+
 # [7.0.3]
 - update trapperkeeper-webserver-jetty9 to 4.5.0, adds opt-in feature to provide access to pending jetty response.
 

--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,7 @@
                          [com.fasterxml.jackson.core/jackson-core "2.14.0"]
                          [com.fasterxml.jackson.core/jackson-databind "2.14.0"]
                          [com.fasterxml.jackson.module/jackson-module-afterburner "2.14.0"]
-                         [org.yaml/snakeyaml "1.33"]
+                         [org.yaml/snakeyaml "2.0"]
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]
                          [org.apache.commons/commons-exec "1.3"]


### PR DESCRIPTION
This updates snakeyaml to 1.3.3 to version 2.0 which resolves CVE-2022-1471

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
