### PR TITLE
(PE-36775) update trapperkeeper-authorization and prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+# [7.1.1]
+- update trapperkeeper-authorization to 2.0.1 to remove verbose warnings, and update dependencies
+
 # [7.1.0]
 - update snakeyaml to 2.0 from 1.3.3 to address CVE-2022-1471
 - update logback to version 1.3.7, 1.2.x is no longer maintained

--- a/project.clj
+++ b/project.clj
@@ -115,7 +115,7 @@
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version]
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version :classifier "test"]
                          [puppetlabs/trapperkeeper-scheduler "1.1.3"]
-                         [puppetlabs/trapperkeeper-authorization "1.0.0"]
+                         [puppetlabs/trapperkeeper-authorization "2.0.1"]
                          [puppetlabs/trapperkeeper-status "1.1.2"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.2.2"]
                          [puppetlabs/structured-logging "0.2.0"]


### PR DESCRIPTION
In two commits, this updates trapperkeeper-authorization to 2.0.1 to remove some unneeded verbose warnings, and to capture some dependency updates.  It also prepares for a new `z` release.