### PR TITLE
(maint) Update joda-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [unreleased]
+- update joda-time
 
 ## [5.5.0]
 - remove clj-yaml dependency to eliminate exposure to snakeyaml 1.33 CVE

--- a/project.clj
+++ b/project.clj
@@ -60,7 +60,7 @@
                          [commons-lang "2.6"]
                          [commons-logging "1.2"]
                          [commons-io "2.8.0"]
-                         [joda-time "2.8.2"]
+                         [joda-time "2.12.5"]
 
                          [com.taoensso/nippy "3.1.1"]
                          [com.taoensso/encore "3.9.2"]


### PR DESCRIPTION
We are very behind. JRuby has kept up to date and for our next update
want to move jruby-deps to use clj-parent. To prepare for this we should
update joda-time to the latest release.