### PR TITLE
Update jvm-ssl-utils to 3.5.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -104,7 +104,7 @@
                          [puppetlabs/http-client "2.1.1"]
                          [puppetlabs/jdbc-util "1.4.0"]
                          [puppetlabs/typesafe-config "0.2.0"]
-                         [puppetlabs/ssl-utils "3.5.0"]
+                         [puppetlabs/ssl-utils "3.5.1"]
                          [puppetlabs/clj-ldap "0.4.0"]
                          [puppetlabs/kitchensink ~ks-version]
                          [puppetlabs/kitchensink ~ks-version :classifier "test"]


### PR DESCRIPTION
Needed for updating BouncyCastle to 1.76

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
