### PR TITLE
(maint) prepare for a new release 5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [unreleased]
+
+## [5.6.0]
 - update joda-time
 - update bouncycastle versions, remove jdk15on versions as we no longer use them
 

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 (def rbac-client-version "1.1.4")
 (def dropwizard-metrics-version "3.2.2")
 
-(defproject puppetlabs/clj-parent "5.5.3-SNAPSHOT"
+(defproject puppetlabs/clj-parent "5.6.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.


### PR DESCRIPTION
The "y" version was bumped due to the removal of the old bouncy-castle library versions that aren't used anymore.

