### PR TITLE
(PE-36367) roll bouncy castle back to 1.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.6.1]
+- roll bouncycastle back to 1.74 to resolve issues with jRuby compatibility.
+
 ## [5.6.0]
 - update joda-time
 - update bouncycastle versions, remove jdk15on versions as we no longer use them

--- a/project.clj
+++ b/project.clj
@@ -139,10 +139,10 @@
                          [org.bouncycastle/bcpkix-fips "1.0.7"]
                          [org.bouncycastle/bc-fips "1.0.2.3"]
                          [org.bouncycastle/bctls-fips "1.0.17"]
-                         [org.bouncycastle/bcpkix-jdk18on "1.76"]
-                         [org.bouncycastle/bctls-jdk18on "1.76"]
-                         [org.bouncycastle/bcprov-jdk18on "1.76"]
-                         [org.bouncycastle/bcutil-jdk18on "1.76"]]
+                         [org.bouncycastle/bcpkix-jdk18on "1.74"]
+                         [org.bouncycastle/bctls-jdk18on "1.74"]
+                         [org.bouncycastle/bcprov-jdk18on "1.74"]
+                         [org.bouncycastle/bcutil-jdk18on "1.74"]]
 
   :dependencies [[org.clojure/clojure]]
 


### PR DESCRIPTION
Roll bouncy castle back to 1.74 to restore deprecated interfaces that jRuby uses that were removed in 1.75.