### PR TITLE
(PE-36979) update tk-webserver-jetty9 to 4.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [unreleased]
+- update trapperkeeper-webserver-jetty9 to resolve CVE-2023-36478 and CVE-2023-44487
 
 ## [5.6.3]
 - update bc-fips to resolve CVE-2022-45156 and CVE-2023-33202

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.11.1")
 (def ks-version "3.2.1")
 (def tk-version "3.3.1")
-(def tk-jetty-version "4.5.1")
+(def tk-jetty-version "4.5.2")
 (def tk-metrics-version "1.5.1")
 (def logback-version "1.3.7")
 (def rbac-client-version "1.1.4")


### PR DESCRIPTION
This update addresses two CVEs: CVE-2023-36478 and CVE-2023-44487

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
