### PR TITLE
(PE-36979) update trapperkeeper-jetty9 to 4.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [unreleased]
+- update trapperkeeper-webserver-jetty9 to 4.5.2 to resolve CVE-2023-36478 and CVE-2023-44487
+
 # [7.2.3]
 - update bc-fips to 1.0.2.4 to resolve CVE-2022-45156 and CVE-2023-33202
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.11.1")
 (def ks-version "3.2.3")
 (def tk-version "4.0.0")
-(def tk-jetty-version "4.5.1")
+(def tk-jetty-version "4.5.2")
 (def tk-metrics-version "1.5.1")
 (def logback-version "1.3.7")
 (def rbac-client-version "1.1.4")


### PR DESCRIPTION
This addresses two CVES: CVE-2023-36478 and CVE-2023-44487

