### PR TITLE
(maint) Update jruby-utils to bring in JRuby 9.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [unreleased]
+- update jruby-utils to bring in JRuby 9.3.11
 
 ## [5.6.4]
 - update trapperkeeper-webserver-jetty9 to resolve CVE-2023-36478 and CVE-2023-44487

--- a/project.clj
+++ b/project.clj
@@ -129,7 +129,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.2.0"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "4.0.3"]
+                         [puppetlabs/jruby-utils "4.1.0"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
