### PR TITLE
(maint) update kitchensink to 3.2.4, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [7.2.7]
+- update kitchensink to 3.2.4 to bring in some new functions, and deprecate old interfaces
+
 ## [7.2.6]
 - Update clj-rbac-client to 1.1.5, adds configurable connection limits
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.11.1")
-(def ks-version "3.2.3")
+(def ks-version "3.2.4")
 (def tk-version "4.0.0")
 (def tk-jetty-version "4.5.2")
 (def tk-metrics-version "1.5.1")


### PR DESCRIPTION
This updates clj-kitchensink to 3.2.4 and prepares for a new 7.2.7 version of clj-parent.

