### PR TITLE
(PE-35510) update tk-metrics back to 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [7.2.9]
+- rollback tk-metrics to 1.5.1 until jetty10 is updated in all the things
+
 ## [7.2.8]
 - add trapperkeeper-webserver-jetty10 version 1.0.4 and trapperkeeper-metrics 2.0.0 using jetty 10
 

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
 (def tk-version "4.0.0")
 (def tk-jetty-9-version "4.5.2")
 (def tk-jetty-10-version "1.0.4")
-(def tk-metrics-version "2.0.0")
+(def tk-metrics-version "1.5.1")
 (def logback-version "1.3.7")
 (def rbac-client-version "1.1.5")
 (def dropwizard-metrics-version "3.2.2")


### PR DESCRIPTION
Due to compatiblity issues with jetty9 and tk-metrics 2.0, the version of metrics needs to be rolled back to 1.5.1 and manually bumped in dependent projects until all the projects are using jetty10 and jetty9 can be removed.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
