### PR TITLE
(maint) Bump tk-jetty-10 to 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [7.2.11]
+- bump tk-jetty-10 to 1.0.5 to include org.eclipse.jetty.server.Response in ring handler :response key
+
 ## [7.2.10]
 - fix accidental wrong namespace for tk-jetty-10
 

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "3.2.4")
 (def tk-version "4.0.0")
 (def tk-jetty-9-version "4.5.2")
-(def tk-jetty-10-version "1.0.4")
+(def tk-jetty-10-version "1.0.5")
 (def tk-metrics-version "1.5.1")
 (def logback-version "1.3.7")
 (def rbac-client-version "1.1.5")


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
