### PR TITLE
(PE-37252) update jetty 10 to not use logback-access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [7.2.12]
+- update jetty-10 to 1.0.6 to not use logback-access for logging because of incompatibilities
+
 ## [7.2.11]
 - bump tk-jetty-10 to 1.0.5 to include org.eclipse.jetty.server.Response in ring handler :response key
 

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "3.2.4")
 (def tk-version "4.0.0")
 (def tk-jetty-9-version "4.5.2")
-(def tk-jetty-10-version "1.0.5")
+(def tk-jetty-10-version "1.0.6")
 (def tk-metrics-version "1.5.1")
 (def logback-version "1.3.7")
 (def rbac-client-version "1.1.5")


### PR DESCRIPTION
This updates jetty10 to 1.0.6, which disables logging through logback-acces.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
