### PR TITLE
(PE-37265) update jetty-10, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [7.2.16]
+- tk-jetty-10 to 1.0.12 to enable access logging again
+
 ## [7.2.15]
 - tk-jetty-10 to 1.0.11 to address character-set issues.
 

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "3.2.4")
 (def tk-version "4.0.0")
 (def tk-jetty-9-version "4.5.2")
-(def tk-jetty-10-version "1.0.11")
+(def tk-jetty-10-version "1.0.12")
 (def tk-metrics-version "1.5.1")
 (def logback-version "1.3.7")
 (def rbac-client-version "1.1.5")


### PR DESCRIPTION
This updates jetty10 to 1.0.12, and prepares for another release.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
