### PR TITLE
(PE-34094) update tk-j10 to 1.0.14; prep for 7.2.18 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## [unreleased]
 
-## [7.2.17]
-- tk-jetty-10 to 1.0.13 to handle and exception when the access log is missing.
+## [7.2.18]
+- update tk-jetty-10 to 1.0.14 to fix a null RequestLogger exception
 
+## [7.2.17]
+- update tk-jetty-10 to 1.0.13 to handle and exception when the access log is missing.
 
 ## [7.2.16]
-- tk-jetty-10 to 1.0.12 to enable access logging again
+- update tk-jetty-10 to 1.0.12 to enable access logging again
 
 ## [7.2.15]
 - tk-jetty-10 to 1.0.11 to address character-set issues.

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "3.2.4")
 (def tk-version "4.0.0")
 (def tk-jetty-9-version "4.5.2")
-(def tk-jetty-10-version "1.0.13")
+(def tk-jetty-10-version "1.0.14")
 (def tk-metrics-version "1.5.1")
 (def logback-version "1.3.7")
 (def rbac-client-version "1.1.5")


### PR DESCRIPTION
Waiting on the fix landing in tk-j10 and a new release of that.
