### PR TITLE
(PE-37321) update logback to 1.3.14, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.6.7]
+- update logback to 1.3.14 to resolve CVE-2023-6378 (see https://logback.qos.ch/news.html#1.3.14)
+
 ## [5.6.6]
 - Revert "update jruby-utils to bring in JRuby 9.3.11"
 

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
 (def tk-version "3.3.1")
 (def tk-jetty-version "4.5.2")
 (def tk-metrics-version "1.5.1")
-(def logback-version "1.3.7")
+(def logback-version "1.3.14")
 (def rbac-client-version "1.1.4")
 (def dropwizard-metrics-version "3.2.2")
 


### PR DESCRIPTION
This updates logback to 1.3.14 to address CVE-2023-6378 / CVE-2023-6381

It also prepares for a release.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
