### PR TITLE
(maint) update clj-kitchensink to 3.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [unreleased]
+- update clj-kitchensink to 3.2.5 to address potential writer leak 
 
 ## [7.3.0]
 - remove jetty9 dependencies, bump tk-metrics to 2.0.1 to move to Jetty10 version

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.11.1")
-(def ks-version "3.2.4")
+(def ks-version "3.2.5")
 (def tk-version "4.0.0")
 (def tk-jetty-10-version "1.0.15")
 (def tk-metrics-version "2.0.1")


### PR DESCRIPTION
This updates clj-kitchensink to 3.2.5 to address a potential writer leak in the `atomic-write` function if the `write-function` throws an exception.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
