### PR TITLE
(PE-37293) Bump tk-jetty to 1.0.16 to add debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## [unreleased]
+## [7.3.1]
+- update tk-jetty-10 to 1.0.16 to add server configuration debug logging on service start
 - update clj-kitchensink to 3.2.5 to address potential writer leak 
 
 ## [7.3.0]

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.11.1")
 (def ks-version "3.2.5")
 (def tk-version "4.0.0")
-(def tk-jetty-10-version "1.0.15")
+(def tk-jetty-10-version "1.0.16")
 (def tk-metrics-version "2.0.1")
 (def logback-version "1.3.14")
 (def rbac-client-version "1.1.5")


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
