### PR TITLE
(maint) update postgres driver to 42.7.1, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+## [7.3.2]
+- update postgres driver to 42.7.1 from 42.4.3 for bug fixes and performance improvements
+
 ## [7.3.1]
 - update tk-jetty-10 to 1.0.16 to add server configuration debug logging on service start
 - update clj-kitchensink to 3.2.5 to address potential writer leak 

--- a/project.clj
+++ b/project.clj
@@ -95,7 +95,7 @@
                          ;; Remove once all projects are updated to use honeysql 2.x
                          [honeysql "1.0.461"]
                          [com.github.seancorfield/honeysql "2.3.911"]
-                         [org.postgresql/postgresql "42.4.3"]
+                         [org.postgresql/postgresql "42.7.1"]
                          [medley "1.0.0"]
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.12"]


### PR DESCRIPTION
This updates the postgres driver from 42.7.1 that contains multiple fixes including:

https://jdbc.postgresql.org/changelogs/2023-12-06-42.7.1-release/
 https://jdbc.postgresql.org/changelogs/2023-11-20-42.7.0-release/ 
https://jdbc.postgresql.org/changelogs/2023-03-17-42.6.0-release/ 
https://jdbc.postgresql.org/changelogs/2023-02-16-42.5.4-release/
 https://jdbc.postgresql.org/changelogs/2023-02-03-42.5.3-release/ 
https://jdbc.postgresql.org/changelogs/2022-11-23-42.5.2-release/ 
https://jdbc.postgresql.org/changelogs/2022-11-23-42.5.1-release/ 
https://jdbc.postgresql.org/changelogs/2022-08-24-42.5.0-release/

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
