### PR TITLE
(maint) add license to project.clj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
-## [7.3.2]
+## [7.3.3]
+- add license to project.clj so that clojars will accept publishing
+
+## [7.3.2] - unpublished
 - update postgres driver to 42.7.1 from 42.4.3 for bug fixes and performance improvements
 
 ## [7.3.1]

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,8 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
   :packaging "pom"
+  :license {:name "Apache-2.0"
+            :url "https://www.apache.org/licenses/LICENSE-2.0.txt"}
 
   :managed-dependencies [[org.clojure/clojure ~clj-version]
                          [org.clojure/clojurescript "1.10.866"]


### PR DESCRIPTION
This adds the apache license block to the project.clj to allow it to be properly published to clojars.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
