### PR TITLE
(PE-37455) update http-client to 2.1.2, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [7.3.4]
+- update clj-http-client to 2.1.2 to allow multiple Set-Cookie headers to be returned in the header map of a response separated by newlines
+
 ## [7.3.3]
 - add license to project.clj so that clojars will accept publishing
 

--- a/project.clj
+++ b/project.clj
@@ -103,7 +103,7 @@
                          [prismatic/schema "1.1.12"]
                          [stylefruits/gniazdo "1.2.1"]
 
-                         [puppetlabs/http-client "2.1.1"]
+                         [puppetlabs/http-client "2.1.2"]
                          [puppetlabs/jdbc-util "1.4.0"]
                          [puppetlabs/typesafe-config "0.2.0"]
                          [puppetlabs/ssl-utils "3.5.2"]


### PR DESCRIPTION
This updates http-client to 2.1.2, to provide support for multiple `Set-Cookie` headers in a response. The response contains the headers in a map, which prevents multiple `Set-Cookie` headers individually, so they are compbined together in one entry separated by newlines.

This also preparse for the 7.3.4 release

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
