### PR TITLE
(PE-37632) update jetty 10 to 10.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [7.3.5] 
+- update tk-jetty10 to bring in a new version of jetty 10 at 10.0.20 to fix some websocket race conditions
+
 ## [7.3.4]
 - update clj-http-client to 2.1.2 to allow multiple Set-Cookie headers to be returned in the header map of a response separated by newlines
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.11.1")
 (def ks-version "3.2.5")
 (def tk-version "4.0.0")
-(def tk-jetty-10-version "1.0.16")
+(def tk-jetty-10-version "1.0.17")
 (def tk-metrics-version "2.0.1")
 (def logback-version "1.3.14")
 (def rbac-client-version "1.1.5")


### PR DESCRIPTION
This addresses some issues with potential race conditions in websockets.

It also prepares for a release.