### PR TITLE
(PE-37632) add jetty 10 as listed dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [7.4.0]
+- add jetty 10 dependencies in this project to allow multiple projects to consolidate on the versions used
+
 ## [7.3.5] 
 - update tk-jetty10 to bring in a new version of jetty 10 at 10.0.20 to fix some websocket race conditions
 

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
 (def logback-version "1.3.14")
 (def rbac-client-version "1.1.5")
 (def dropwizard-metrics-version "3.2.2")
+(def jetty-10-version "10.0.20")
 
 (defproject puppetlabs/clj-parent "7.3.6-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
@@ -144,7 +145,15 @@
                          [org.bouncycastle/bcpkix-jdk18on "1.74"]
                          [org.bouncycastle/bctls-jdk18on "1.74"]
                          [org.bouncycastle/bcprov-jdk18on "1.74"]
-                         [org.bouncycastle/bcutil-jdk18on "1.74"]]
+                         [org.bouncycastle/bcutil-jdk18on "1.74"]
+
+                         [org.eclipse.jetty/jetty-server ~jetty-10-version]
+                         [org.eclipse.jetty/jetty-servlet ~jetty-10-version]
+                         [org.eclipse.jetty/jetty-servlets ~jetty-10-version]
+                         [org.eclipse.jetty/jetty-webapp ~jetty-10-version]
+                         [org.eclipse.jetty/jetty-proxy ~jetty-10-version]
+                         [org.eclipse.jetty/jetty-jmx ~jetty-10-version]
+                         [org.eclipse.jetty.websocket/websocket-jetty-server ~jetty-10-version]]
 
   :dependencies [[org.clojure/clojure]]
 

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 (def dropwizard-metrics-version "3.2.2")
 (def jetty-10-version "10.0.20")
 
-(defproject puppetlabs/clj-parent "7.3.6-SNAPSHOT"
+(defproject puppetlabs/clj-parent "7.4.0-SNAPSHOT"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.


### PR DESCRIPTION
Multiple projects depends on the jetty 10 version.  This moves it here to allow the version to be managed centrally.

It also prepares for a new release.
