### PR TITLE
(PE-37632) update webserver-jetty-10 to 1.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [7.3.6]
+- update tk-jetty10 to include the websocket libraries from jetty 10 so they can be centrally managed
+
 ## [7.3.5] 
 - update tk-jetty10 to bring in a new version of jetty 10 at 10.0.20 to fix some websocket race conditions
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def clj-version "1.11.1")
 (def ks-version "3.2.5")
 (def tk-version "4.0.0")
-(def tk-jetty-10-version "1.0.17")
+(def tk-jetty-10-version "1.0.18")
 (def tk-metrics-version "2.0.1")
 (def logback-version "1.3.14")
 (def rbac-client-version "1.1.5")


### PR DESCRIPTION
This updates webserver-jetty-10 to 1.0.18 to add some websocket
client dependencies to allow the jetty version to be centrally
managed.