### PR TITLE
(PE-37632) update trapperkeeper metrics to 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [7.3.7]
+- update tk-metrics to 2.0.3 to leverage the version of tk-webserver-jetty-10 from clj-parent
+
 ## [7.3.6]
 - update tk-jetty10 to include the websocket libraries from jetty 10 so they can be centrally managed
 

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "3.2.5")
 (def tk-version "4.0.0")
 (def tk-jetty-10-version "1.0.18")
-(def tk-metrics-version "2.0.1")
+(def tk-metrics-version "2.0.3")
 (def logback-version "1.3.14")
 (def rbac-client-version "1.1.5")
 (def dropwizard-metrics-version "3.2.2")


### PR DESCRIPTION
This updates trapperkeeper metrics to 2.0.3 so that it uses clj-parent
for determining the version of tk-ws-jetty10 to include.