### PR TITLE
(PE-37632) update trapperkeeper-status to 1.2.0, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [7.3.8]
+- update tk-status to 1.2.0 to remove ring-defaults dependency
+
 ## [7.3.7]
 - update tk-metrics to 2.0.3 to leverage the version of tk-webserver-jetty-10 from clj-parent
 

--- a/project.clj
+++ b/project.clj
@@ -118,7 +118,7 @@
                          [puppetlabs/trapperkeeper-metrics ~tk-metrics-version :classifier "test"]
                          [puppetlabs/trapperkeeper-scheduler "1.1.3"]
                          [puppetlabs/trapperkeeper-authorization "2.0.1"]
-                         [puppetlabs/trapperkeeper-status "1.1.2"]
+                         [puppetlabs/trapperkeeper-status "1.2.0"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.2.2"]
                          [puppetlabs/structured-logging "0.2.0"]
                          [puppetlabs/ring-middleware "1.3.1"]


### PR DESCRIPTION
See individual commit comments.