### PR TITLE
(PE-37762) update Postgres to 42.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [unreleased]
+## [5.6.8]
+- update postgres driver to 42.4.4 to address  CVE-2024-1597 (see https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-24rp-q3w6-vc56) 
 
 ## [5.6.7]
 - update logback to 1.3.14 to resolve CVE-2023-6378 (see https://logback.qos.ch/news.html#1.3.14)

--- a/project.clj
+++ b/project.clj
@@ -95,7 +95,7 @@
                          ;; Remove once all projects are updated to use honeysql 2.x
                          [honeysql "1.0.461"]
                          [com.github.seancorfield/honeysql "2.3.911"]
-                         [org.postgresql/postgresql "42.4.3"]
+                         [org.postgresql/postgresql "42.4.4"]
                          [medley "1.0.0"]
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.12"]


### PR DESCRIPTION
This addresses https://github.com/advisories/GHSA-xfg6-62px-cxc2.
