### PR TITLE
(PE-37762) update postgres to 42.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+## [7.3.9]
+- update postgres to 42.7.2 to address CVE-2024-1597 (see https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-24rp-q3w6-vc56)
 
 ## [7.3.8]
 - update tk-status to 1.2.0 to remove ring-defaults dependency

--- a/project.clj
+++ b/project.clj
@@ -97,7 +97,7 @@
                          ;; Remove once all projects are updated to use honeysql 2.x
                          [honeysql "1.0.461"]
                          [com.github.seancorfield/honeysql "2.3.911"]
-                         [org.postgresql/postgresql "42.7.1"]
+                         [org.postgresql/postgresql "42.7.2"]
                          [medley "1.0.0"]
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.12"]


### PR DESCRIPTION
This addresses [CVE-2024-1597](https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-24rp-q3w6-vc56)