### PR TITLE
(maint) add license entry, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
-## [5.6.8]
+## [5.6.9] 
+- add license to project.clj to allow push to clojars
+
+## [5.6.8] (not released)
 - update postgres driver to 42.4.4 to address  CVE-2024-1597 (see https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-24rp-q3w6-vc56) 
 
 ## [5.6.7]

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,8 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
   :packaging "pom"
+  :license {:name "Apache-2.0"
+            :url "https://www.apache.org/licenses/LICENSE-2.0.txt"}
 
   :managed-dependencies [[org.clojure/clojure ~clj-version]
                          [org.clojure/clojurescript "1.10.866"]


### PR DESCRIPTION
This adds the license entry to project.clj to allow it to be published on clojars.  It also adjusts the changelog to indicate that 5.6.8 wasn't properly released.