### PR TITLE
(PE-37763) update commons-compress to 1.26, commons-exec, commons-lang3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Unreleased
+## [7.3.10]
+- update apache-commons/commons-compress to 1.26.0 to address CVE-2024-25710 CVE-2024-26308 and CVE-2023-42503
+- update apache-commons/commons-lang3 to latest
+- update apache-commons/commons-exec to latest
+
 ## [7.3.9]
 - update postgres to 42.7.2 to address CVE-2024-1597 (see https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-24rp-q3w6-vc56)
 

--- a/project.clj
+++ b/project.clj
@@ -50,9 +50,9 @@
                          [org.yaml/snakeyaml "2.0"]
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]
-                         [org.apache.commons/commons-exec "1.3"]
-                         [org.apache.commons/commons-compress "1.21"]
-                         [org.apache.commons/commons-lang3 "3.4"]
+                         [org.apache.commons/commons-exec "1.4.0"]
+                         [org.apache.commons/commons-compress "1.26.0"]
+                         [org.apache.commons/commons-lang3 "3.14.0"]
                          [org.apache.httpcomponents/httpclient  "4.5.13"]
                          [org.apache.httpcomponents/httpcore  "4.4.15"]
                          [org.apache.httpcomponents/httpasyncclient "4.1.5"]


### PR DESCRIPTION
This updates `org.apache.commons/commons-exec` to `1.26.0` to address CVE-2024-25710 CVE-2024-26308 and CVE-2023-42503
It also updates `org.apache.commons/commons-lang3` to `3.14.0` as the previous version was released in 2014.
It also updates `org.apache.commons/commons-exec` to the latest version `1.4.0`

