### PR TITLE
(PE-37763) update commons-compress to 1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## [unreleased]
+
+## [5.6.10]
+- update `org.apache.commons/commons-compress` to `1.26.0` to address CVE-2024-25710 CVE-2024-26308 and CVE-2023-42503
+
 ## [5.6.9] 
 - add license to project.clj to allow push to clojars
 

--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
 
                          [org.apache.maven.wagon/wagon-provider-api "2.10"]
                          [org.apache.commons/commons-exec "1.3"]
-                         [org.apache.commons/commons-compress "1.21"]
+                         [org.apache.commons/commons-compress "1.26.0"]
                          [org.apache.commons/commons-lang3 "3.4"]
                          [org.apache.httpcomponents/httpclient  "4.5.13"]
                          [org.apache.httpcomponents/httpcore  "4.4.15"]


### PR DESCRIPTION
This updates `org.apache.commons/commons-exec` to `1.26.0` to address CVE-2024-25710 CVE-2024-26308 and CVE-2023-42503