### PR TITLE
Update commons-io to 2.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.6.11]
+- update commons-io to 2.15.1 for compatibility with commons-compress 1.26.0
+
 ## [5.6.10]
 - update `org.apache.commons/commons-compress` to `1.26.0` to address CVE-2024-25710 CVE-2024-26308 and CVE-2023-42503
 

--- a/project.clj
+++ b/project.clj
@@ -61,7 +61,7 @@
                          [commons-collections "3.2.2"]
                          [commons-lang "2.6"]
                          [commons-logging "1.2"]
-                         [commons-io "2.8.0"]
+                         [commons-io "2.15.1"]
                          [joda-time "2.12.5"]
 
                          [com.taoensso/nippy "3.1.1"]


### PR DESCRIPTION
apache-compress 1.26.0 (COMPRESS-632) moved to using a FileTimes class
in commons-io that was added to commons-io in 2.12.0.