### PR TITLE
(maint)  update clj-http-client to 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## [7.3.13]
+- update clj-http client to 2.1.3 to fix issue with 204 handling of unbuffered-stream mode
+
+## [7.3.12]
+- add the clj-host-action-collector-client version to the set of managed versions
+
 ## [7.3.11]
 - update commons-io to 2.15.1 for compatibility with commons-compress 1.26.0
 

--- a/project.clj
+++ b/project.clj
@@ -104,7 +104,7 @@
                          [stylefruits/gniazdo "1.2.1"]
 
                          [puppetlabs/host-action-collector-client "0.1.4"]
-                         [puppetlabs/http-client "2.1.2"]
+                         [puppetlabs/http-client "2.1.3"]
                          [puppetlabs/jdbc-util "1.4.0"]
                          [puppetlabs/typesafe-config "0.2.0"]
                          [puppetlabs/ssl-utils "3.5.2"]


### PR DESCRIPTION
This updates clj-http-client to 2.1.3 to allow for correct 204 handling
in the unbuffered stream client.
