### PR TITLE
(maint) update host-action-collector-client to 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [7.3.14]
+- update host-action-collector-client to 0.1.5 to add handling and logging of nil status results
+
 ## [7.3.13]
 - update clj-http client to 2.1.3 to fix issue with 204 handling of unbuffered-stream mode
 

--- a/project.clj
+++ b/project.clj
@@ -103,7 +103,7 @@
                          [prismatic/schema "1.1.12"]
                          [stylefruits/gniazdo "1.2.1"]
 
-                         [puppetlabs/host-action-collector-client "0.1.4"]
+                         [puppetlabs/host-action-collector-client "0.1.5"]
                          [puppetlabs/http-client "2.1.3"]
                          [puppetlabs/jdbc-util "1.4.0"]
                          [puppetlabs/typesafe-config "0.2.0"]


### PR DESCRIPTION
This updates `host-action-collector-client` to `0.1.5` which brings in handling for `nil` status results from requests, and specific logging for documenting the cause of those cases.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
