### PR TITLE
(PDB-5730) Update pgjdbc to 42.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.6.13]
+- update pgjdbc version to 42.4.5 to resolve https://github.com/pgjdbc/pgjdbc/issues/3014
+
 ## [5.6.12]
 - update clojure version to 1.11.2 to resolve https://github.com/advisories/GHSA-vr64-r9qj-h27f CVE
 

--- a/project.clj
+++ b/project.clj
@@ -97,7 +97,7 @@
                          ;; Remove once all projects are updated to use honeysql 2.x
                          [honeysql "1.0.461"]
                          [com.github.seancorfield/honeysql "2.3.911"]
-                         [org.postgresql/postgresql "42.4.4"]
+                         [org.postgresql/postgresql "42.4.5"]
                          [medley "1.0.0"]
                          [prismatic/plumbing "0.4.2"]
                          [prismatic/schema "1.1.12"]


### PR DESCRIPTION
Resolved a bug in pgjdbc
https://github.com/pgjdbc/pgjdbc/issues/3014

which resulted in a failure in PuppetDB due to
java.lang.NoSuchMethodError: java.nio.ByteBuffer.position(I)Ljava/nio/ByteBuffer

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
