### PR TITLE
(PE-37186) update host-action-collector-client to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [7.3.15]
+- update host-action-collector-client to 0.1.6 to allow optional date field specification
+
 ## [7.3.14]
 - update clojure version to 1.11.2 to resolve https://github.com/advisories/GHSA-vr64-r9qj-h27f CVE
 - update host-action-collector-client to 0.1.5 to add handling and logging of nil status results

--- a/project.clj
+++ b/project.clj
@@ -103,7 +103,7 @@
                          [prismatic/schema "1.1.12"]
                          [stylefruits/gniazdo "1.2.1"]
 
-                         [puppetlabs/host-action-collector-client "0.1.5"]
+                         [puppetlabs/host-action-collector-client "0.1.6"]
                          [puppetlabs/http-client "2.1.3"]
                          [puppetlabs/jdbc-util "1.4.0"]
                          [puppetlabs/typesafe-config "0.2.0"]


### PR DESCRIPTION
Also prepares for a release.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
