### PR TITLE
(maint) update clj-kitchensink to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+## [7.3.17]
+- update clj-kitchensink which adds new time functions
 
 ## [7.3.16]
 - update jdbc-utils to 1.4.2 to resolve issue with sequence reconciliation

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.11.2")
-(def ks-version "3.2.5")
+(def ks-version "3.3.0")
 (def tk-version "4.0.0")
 (def tk-jetty-10-version "1.0.18")
 (def tk-metrics-version "2.0.3")


### PR DESCRIPTION
This updates clj-kitchensink which adds new time functions that
can be used to parse Puppet durations, and will aid with the move
away from clj-time.