### PR TITLE
(maint) Bump kitchensink to 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.6.15]
+- update clj-kitchensink to 3.3.1 which adds new time functions
+
 ## [5.6.14]
 - update jdbc-utils to 1.4.2 to resolve issue with sequence reconciliation
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.11.2")
-(def ks-version "3.2.1")
+(def ks-version "3.3.1")
 (def tk-version "3.3.1")
 (def tk-jetty-version "4.5.2")
 (def tk-metrics-version "1.5.1")


### PR DESCRIPTION
Bumping kitchensink for 5.x for time parsing function in https://github.com/puppetlabs/clj-kitchensink/pull/132.

Although we aren't removing clj-time in 2021.7.x, might as well keep the work for https://perforce.atlassian.net/browse/PE-38243 consistent for 2021.7.x and main.