### PR TITLE
(PE-37972) update jdbc-util to 1.4.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -104,7 +104,7 @@
                          [stylefruits/gniazdo "1.2.1"]
 
                          [puppetlabs/http-client "2.1.1"]
-                         [puppetlabs/jdbc-util "1.4.2"]
+                         [puppetlabs/jdbc-util "1.4.3"]
                          [puppetlabs/typesafe-config "0.2.0"]
                          [puppetlabs/ssl-utils "3.5.2"]
                          [puppetlabs/clj-ldap "0.4.0"]


### PR DESCRIPTION
This commit updates jdbc-util to 1.4.3, which brings in a new version that was built against the dependencies on clj-parent 5.6.15 which has and updated version of pgjdbc. While we were not shipping a vulnerable version of pgjdbc since that was up-to-date in clj-parent, the dep in jdbc-util was still triggering the mend scans.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
