### PR TITLE
(maint) update action versions

### DIFF
--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -9,22 +9,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: connect_twingate
-      uses: twingate/github-action@v1
+      uses: twingate/github-action@v1.1
       with:
         service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
     - name: checkout repo content
-      uses: actions/checkout@v2 # checkout the repository content to github runner.
+      uses: actions/checkout@v4 # checkout the repository content to github runner.
       with:
         fetch-depth: 1
     # install java which is required for mend and clojure
     - name: setup java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: 17
     # install clojure tools
     - name: Install Clojure tools
-      uses: DeLaGuardo/setup-clojure@10.1
+      uses: DeLaGuardo/setup-clojure@12.5
       with:
         # Install just one or all simultaneously
         # The value must indicate a particular version of the tool, or use 'latest'


### PR DESCRIPTION
This updates the version of twingate, java, clojure and the checkout actions to be the latest versions.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
