### PR TITLE
(maint) update trapperkeeper-filesystem-watcher to 1.2.3 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [7.3.21]
+- update file-sync-watcher to 1.2.3  conditionalize potentially expensive logging
+
 ## [7.3.20]
 - update host-action-collector-client to 0.1.7 to add purging of directories older than 30 days
 

--- a/project.clj
+++ b/project.clj
@@ -120,7 +120,7 @@
                          [puppetlabs/trapperkeeper-scheduler "1.1.3"]
                          [puppetlabs/trapperkeeper-authorization "2.0.1"]
                          [puppetlabs/trapperkeeper-status "1.2.0"]
-                         [puppetlabs/trapperkeeper-filesystem-watcher "1.2.2"]
+                         [puppetlabs/trapperkeeper-filesystem-watcher "1.2.3"]
                          [puppetlabs/structured-logging "0.2.0"]
                          [puppetlabs/ring-middleware "1.3.1"]
                          [puppetlabs/dujour-version-check "1.0.0"]


### PR DESCRIPTION
This version conditionalizes some potentially expensive logging
when there are a lot of events generated.