### PR TITLE
(maint) update trapperkeeper-filesystem-watcher to 1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Unreleased
 
+## [7.3.22]
+- update trapperkeeper-filesystem-watcher to 1.2.4 to fix conditionalization from 1.2.3 and make shutdown more robust 
+
 ## [7.3.21]
-- update file-sync-watcher to 1.2.3  conditionalize potentially expensive logging
+- update trapperkeeper-filesystem-watcher to 1.2.3 to conditionalize potentially expensive logging
 
 ## [7.3.20]
 - update host-action-collector-client to 0.1.7 to add purging of directories older than 30 days

--- a/project.clj
+++ b/project.clj
@@ -120,7 +120,7 @@
                          [puppetlabs/trapperkeeper-scheduler "1.1.3"]
                          [puppetlabs/trapperkeeper-authorization "2.0.1"]
                          [puppetlabs/trapperkeeper-status "1.2.0"]
-                         [puppetlabs/trapperkeeper-filesystem-watcher "1.2.3"]
+                         [puppetlabs/trapperkeeper-filesystem-watcher "1.2.4"]
                          [puppetlabs/structured-logging "0.2.0"]
                          [puppetlabs/ring-middleware "1.3.1"]
                          [puppetlabs/dujour-version-check "1.0.0"]


### PR DESCRIPTION
This improves the performance when debug logging is disabled. In addition it makes shutdown more robust, catching additional exceptions and ensuring that futures are correctly cancelled on shutdown.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
