### PR TITLE
(maint) Bump tk-version for `logged?` changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [7.2.23]
+- update trapperkeeper to 4.0.1 for `logged?` test utility changes
+
 ## [7.3.22]
 - update trapperkeeper-filesystem-watcher to 1.2.4 to fix conditionalization from 1.2.3 and make shutdown more robust 
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.11.2")
 (def ks-version "3.3.0")
-(def tk-version "4.0.0")
+(def tk-version "4.0.1")
 (def tk-jetty-10-version "1.0.18")
 (def tk-metrics-version "2.0.4")
 (def logback-version "1.3.14")


### PR DESCRIPTION
See https://github.com/puppetlabs/trapperkeeper/pull/313 for details on`logged?` change.