### PR TITLE
(maint) Bump tk-version for `logged?` changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.6.18]
+- update trapperkeeper to 3.3.2 for `logged?` test utility changes
+
 ## [5.6.17]
 - update jruby-utils to 4.1.1 for JRuby 9.3.14 upgrade
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.11.2")
 (def ks-version "3.3.1")
-(def tk-version "3.3.1")
+(def tk-version "3.3.2")
 (def tk-jetty-version "4.5.2")
 (def tk-metrics-version "1.5.1")
 (def logback-version "1.3.14")


### PR DESCRIPTION
Depends on https://github.com/puppetlabs/trapperkeeper/pull/314 being merged first.