### PR TITLE
(PE-38421) update trapperkeeper-file-system-watcher to 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## [7.2.24]
+- update trapperkeeper-filesystem-watcher to 1.2.5 to address stack overflow issue, add interface to watch files
+
 ## [7.2.23]
 - update trapperkeeper to 4.0.1 for `logged?` test utility changes
 

--- a/project.clj
+++ b/project.clj
@@ -120,7 +120,7 @@
                          [puppetlabs/trapperkeeper-scheduler "1.1.3"]
                          [puppetlabs/trapperkeeper-authorization "2.0.1"]
                          [puppetlabs/trapperkeeper-status "1.2.0"]
-                         [puppetlabs/trapperkeeper-filesystem-watcher "1.2.4"]
+                         [puppetlabs/trapperkeeper-filesystem-watcher "1.2.5"]
                          [puppetlabs/structured-logging "0.2.0"]
                          [puppetlabs/ring-middleware "1.3.1"]
                          [puppetlabs/dujour-version-check "1.0.0"]


### PR DESCRIPTION
This fixes an issue with a potential stack overflow when large
number of file system events are being processed. It also adds
specific interfaces to allow watchers to register for changes in
specific files, rather than handling all events and filtering out
the ones that aren't interesting.

In a separate commit, it prepares for release.