### PR TITLE
(PE-38476) update host-action-collector-client to 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Unreleased
+## [7.2.27]
+- update host-action-collector client to 0.1.8 to prevent temporary files from being written with execute permissions
 
 ## [7.2.26]
-- update jruby-tuils to 5.1.3 to parallelize instance creation
+- update jruby-utils to 5.1.3 to parallelize instance creation
 
 ## [7.2.25]
 - update clj-shell-utils to 2.0.1 to allow cwd specification

--- a/project.clj
+++ b/project.clj
@@ -103,7 +103,7 @@
                          [prismatic/schema "1.1.12"]
                          [stylefruits/gniazdo "1.2.1"]
 
-                         [puppetlabs/host-action-collector-client "0.1.7"]
+                         [puppetlabs/host-action-collector-client "0.1.8"]
                          [puppetlabs/http-client "2.1.3"]
                          [puppetlabs/jdbc-util "1.4.3"]
                          [puppetlabs/typesafe-config "0.2.0"]


### PR DESCRIPTION
This updates the client to ensure that data files are not written with execute permissions.

