### PR TITLE
(PE-38477) update kitchensink to 3.4.0 for java.time encoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.6.19]
+- update kitchensink to 3.4.0 for new java.time JSON encoders
+
 ## [5.6.18]
 - update trapperkeeper to 3.3.2 for `logged?` test utility changes
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.11.2")
-(def ks-version "3.3.1")
+(def ks-version "3.4.0")
 (def tk-version "3.3.2")
 (def tk-jetty-version "4.5.2")
 (def tk-metrics-version "1.5.1")


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
