### PR TITLE
(maint) update to trapperkeeper 3.3.3, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+## [5.6.20]
+- update trapperkeeper to 3.3.3 to improve the output from the `logged?` test function
+
 ## [5.6.19]
 - update kitchensink to 3.4.0 for new java.time JSON encoders
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.11.2")
 (def ks-version "3.4.0")
-(def tk-version "3.3.2")
+(def tk-version "3.3.3")
 (def tk-jetty-version "4.5.2")
 (def tk-metrics-version "1.5.1")
 (def logback-version "1.3.14")


### PR DESCRIPTION
See individual commit comments.