### PR TITLE
(maint) update trapperkeeper to 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+## [7.3.31]
+- update trapperkeeper to improve `logged?` output to not be so verbose
 
 ## [7.3.30]
 - update jruby-utils to 5.1.4 for improved jruby instance creation

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.11.2")
 (def ks-version "3.4.0")
-(def tk-version "4.0.1")
+(def tk-version "4.0.2")
 (def tk-jetty-10-version "1.0.18")
 (def tk-metrics-version "2.0.4")
 (def logback-version "1.3.14")


### PR DESCRIPTION
See individual commit comments.