### PR TITLE
(PE-38292) Upgrade to JRuby 9.4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 ## [7.3.32]
-- update jruby-utils to 5.2.0 to get jruby-openssl 0.15 (and its support for modern BouncyCastle)
+- update jruby-utils to 5.2.0 to get JRuby 9.4.8.0 and jruby-openssl 0.15 (and its support for modern BouncyCastle)
 
 ## [7.3.31]
 - update trapperkeeper to improve `logged?` output to not be so verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+## [7.3.32]
+- update jruby-utils to 5.2.0 to get jruby-openssl 0.15 (and its support for modern BouncyCastle)
+
 ## [7.3.31]
 - update trapperkeeper to improve `logged?` output to not be so verbose
 

--- a/project.clj
+++ b/project.clj
@@ -132,7 +132,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.2.0"]
                          [puppetlabs/clj-shell-utils "2.0.1"]
-                         [puppetlabs/jruby-utils "5.1.4"]
+                         [puppetlabs/jruby-utils "5.2.0"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
tag: https://github.com/puppetlabs/jruby-utils/releases/tag/5.2.0