### PR TITLE
(PE-38702) update ring-middleware, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+## [7.3.33]
+- update ring-middleeware to 2.0.3 to add some new standaard wrappers
+
 ## [7.3.32]
 - update jruby-utils to 5.2.0 to get JRuby 9.4.8.0 and jruby-openssl 0.15 (and its support for modern BouncyCastle)
 

--- a/project.clj
+++ b/project.clj
@@ -122,7 +122,7 @@
                          [puppetlabs/trapperkeeper-status "1.2.0"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.2.5"]
                          [puppetlabs/structured-logging "0.2.0"]
-                         [puppetlabs/ring-middleware "1.3.1"]
+                         [puppetlabs/ring-middleware "2.0.3"]
                          [puppetlabs/dujour-version-check "1.0.0"]
                          [puppetlabs/comidi "1.0.0"]
                          [puppetlabs/trapperkeeper-comidi-metrics "0.1.1"]


### PR DESCRIPTION
This updates ring-middleware to 2.0.3 which adds some new standard
wrappers and optimizes the uncaught exception handler.

It also prepares for a new release.