### PR TITLE
(PE-38702) update ring-middleware to 2.0.4, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+## [7.3.34]
+- update ring-middleware to 2.0.4 to add method and uri to unhandled exceptions wrapper
+- 
 ## [7.3.33]
 - update ring-middleeware to 2.0.3 to add some new standaard wrappers
 

--- a/project.clj
+++ b/project.clj
@@ -122,7 +122,7 @@
                          [puppetlabs/trapperkeeper-status "1.2.0"]
                          [puppetlabs/trapperkeeper-filesystem-watcher "1.2.5"]
                          [puppetlabs/structured-logging "0.2.0"]
-                         [puppetlabs/ring-middleware "2.0.3"]
+                         [puppetlabs/ring-middleware "2.0.4"]
                          [puppetlabs/dujour-version-check "1.0.0"]
                          [puppetlabs/comidi "1.0.0"]
                          [puppetlabs/trapperkeeper-comidi-metrics "0.1.1"]


### PR DESCRIPTION
This updates the wrap-uncaught-errors to include the method and uri in the log message to aid debugging of the issue raised by the exception.