### PR TITLE
(maint) Revert back to JRuby 9.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [unreleased]
 
+## [5.6.22]
+- revert jruby-utils upgrade back to JRuby 9.3.14 due to incompatability in pe testing
+
+## [5.6.21]
+- update jruby-utils to 4.2.0 for JRuby 9.3.15 upgrade, this pulls in the latest jruby-openssl maintenance release (and its support for modern BouncyCastle)
+
 ## [5.6.20]
 - update trapperkeeper to 3.3.3 to improve the output from the `logged?` test function
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-## [5.6.21]
-- update jruby-utils to 4.2.0 for JRuby 9.3.15 upgrade, this pulls in the latest jruby-openssl maintenance release (and its support for modern BouncyCastle)
+## [unreleased]
 
 ## [5.6.20]
 - update trapperkeeper to 3.3.3 to improve the output from the `logged?` test function

--- a/project.clj
+++ b/project.clj
@@ -131,7 +131,7 @@
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/analytics-client "1.2.0"]
                          [puppetlabs/clj-shell-utils "1.0.2"]
-                         [puppetlabs/jruby-utils "4.2.0"]
+                         [puppetlabs/jruby-utils "4.1.1"]
 
                          ;; When these versions change we need to also
                          ;; promote the changes into the PE packaging repo


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
