### PR TITLE
(PE-37592) Update tk-fs-watcher to 1.2.6 to compress superfluous events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Unreleased
+
+## [7.3.36]
+- update tk-fs-watcher to 1.2.6 to compress superfluous events
+
 ## [7.3.35]
 - update bouncy castle to latest versions
 

--- a/project.clj
+++ b/project.clj
@@ -120,7 +120,7 @@
                          [puppetlabs/trapperkeeper-scheduler "1.1.3"]
                          [puppetlabs/trapperkeeper-authorization "2.0.1"]
                          [puppetlabs/trapperkeeper-status "1.2.0"]
-                         [puppetlabs/trapperkeeper-filesystem-watcher "1.2.5"]
+                         [puppetlabs/trapperkeeper-filesystem-watcher "1.2.6"]
                          [puppetlabs/structured-logging "0.2.0"]
                          [puppetlabs/ring-middleware "2.0.4"]
                          [puppetlabs/dujour-version-check "1.0.0"]


### PR DESCRIPTION
Please add all notable changes to the "Unreleased" section of the CHANGELOG.
